### PR TITLE
support macOS and FreeBSD PTY functions

### DIFF
--- a/src/daemon.zig
+++ b/src/daemon.zig
@@ -5,15 +5,27 @@ const xev = xevg.Dynamic;
 const clap = @import("clap");
 const config_mod = @import("config.zig");
 const protocol = @import("protocol.zig");
+const builtin = @import("builtin");
 
 const ghostty = @import("ghostty-vt");
 
-const c = @cImport({
-    @cInclude("pty.h");
-    @cInclude("utmp.h");
-    @cInclude("stdlib.h");
-    @cInclude("sys/ioctl.h");
-});
+const c = switch (builtin.os.tag) {
+    .macos => @cImport({
+        @cInclude("sys/ioctl.h"); // ioctl and constants
+        @cInclude("util.h"); // openpty()
+        @cInclude("stdlib.h");
+    }),
+    .freebsd => @cImport({
+        @cInclude("termios.h"); // ioctl and constants
+        @cInclude("libutil.h"); // openpty()
+        @cInclude("stdlib.h");
+    }),
+    else => @cImport({
+        @cInclude("sys/ioctl.h"); // ioctl and constants
+        @cInclude("pty.h");
+        @cInclude("stdlib.h");
+    }),
+};
 
 // Handler for processing VT sequences
 const VTHandler = struct {


### PR DESCRIPTION
Replace Linux-specific PTY headers with platform-specific imports
to enable cross-platform compatibility. On macOS, use util.h for
openpty(). On FreeBSD, use libutil.h for openpty(). On Linux and
other platforms, continue using pty.h.

Remove unused utmp.h include that was never referenced in the code.

This change allows the daemon to compile and run on macOS and
FreeBSD in addition to Linux without requiring platform-specific
preprocessor directives or build configurations.

Amp-Thread-ID: https://ampcode.com/threads/T-15fd58fa-5673-40c5-87e1-3ea0057599ca
Co-authored-by: Amp <amp@ampcode.com>
