### PR TITLE
Bump minimum Zig version

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -25,7 +25,7 @@
     .fingerprint = 0x28aad87005052b4e, // Changing this has security and trust implications.
     // Tracks the earliest Zig version that the package considers to be a
     // supported use case.
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.15.2",
     // This field is optional.
     // Each dependency must either provide a `url` and `hash`, or a `path`.
     // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.


### PR DESCRIPTION
The Ghostty commit referenced in `build.zig.zon` requires Zig version 0.15.2 (see https://github.com/ghostty-org/ghostty/blob/4ff0e0c9d251ddd0687ead578a90d58d63f9840b/build.zig.zon#L6), so `zmx` will fail to build with older Zig versions.