### PR TITLE
add zsh shell prompt documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,12 @@ todo.
 
 ### zsh
 
-todo.
+Place this in `.zshrc`, update current `$PROMPT/$PS1` to `BASE_PROMPT`
+
+```zsh
+BASE_PROMPT=$PS1/$PROMPT
+PROMPT="${ZMX_SESSION:+[$ZMX_SESSION]} $BASE_PROMPT"
+```
 
 ## philosophy
 


### PR DESCRIPTION
This will add instruction to the README for how to get a shell prompt in zsh. Feel free to reword as needed to fit style.