### PR TITLE
Use XDG_RUNTIME_DIR for the socket directory if defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Use spec: https://common-changelog.org/
 
+## Unreleased
+
+### Added
+
+- Use `XDG_RUNTIME_DIR` environment variable for socket directory (takes precedence over `TMPDIR` and `/tmp`)
+
 ## v0.1.1 - 2025-12-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -160,10 +160,12 @@ Wow! Now you can setup all your os tiling windows how you like them for your pro
 
 ## socket file location
 
-Each session gets its own unix socket file. Right now, the default location is `/tmp/zmx-{uid}`. You can configure this using environment variables:
+Each session gets its own unix socket file. The default location depends on your environment variables (checked in priority order):
 
-- `TMPDIR` => overrides `/tmp`
-- `ZMX_DIR` => overrides `/tmp/zmx-{uid}`
+1. `ZMX_DIR` => uses exact path (e.g., `/custom/path`)
+2. `XDG_RUNTIME_DIR` => uses `{XDG_RUNTIME_DIR}/zmx` (recommended on Linux, typically results in `/run/user/{uid}/zmx`)
+3. `TMPDIR` => uses `{TMPDIR}/zmx-{uid}` (appends uid for multi-user safety)
+4. `/tmp` => uses `/tmp/zmx-{uid}` (default fallback, appends uid for multi-user safety)
 
 ## debugging
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -79,12 +79,12 @@ const Cfg = struct {
         const tmpdir = posix.getenv("TMPDIR") orelse "/tmp";
         const uid = posix.getuid();
 
-        var socket_dir: []const u8 = "";
-        if (posix.getenv("ZMX_DIR")) |zmxdir| {
-            socket_dir = try alloc.dupe(u8, zmxdir);
-        } else {
-            socket_dir = try std.fmt.allocPrint(alloc, "{s}/zmx-{d}", .{ tmpdir, uid });
-        }
+        const socket_dir: []const u8 = if (posix.getenv("ZMX_DIR")) |zmxdir|
+            try alloc.dupe(u8, zmxdir)
+        else if (posix.getenv("XDG_RUNTIME_DIR")) |xdg_runtime|
+            try std.fmt.allocPrint(alloc, "{s}/zmx", .{xdg_runtime})
+        else
+            try std.fmt.allocPrint(alloc, "{s}/zmx-{d}", .{ tmpdir, uid });
         errdefer alloc.free(socket_dir);
 
         const log_dir = try std.fmt.allocPrint(alloc, "{s}/logs", .{socket_dir});


### PR DESCRIPTION
XDG_RUNTIME_DIR[0] is a file path for user-specific runtime files, like sockets.

It will typically be defined on Linux. I can't say for sure on BSDs, and I know for certain it is not defined on macOS.

Link: https://specifications.freedesktop.org/basedir/latest/ [0]