### PR TITLE
docs: add instructions on updating the bash shell prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,17 +98,14 @@ function fish_prompt --description 'Write out the prompt'
 end
 ```
 
-### bash
+### bash and zsh
 
-todo.
+Depending on the shell, place this in either `.bashrc` or `.zshrc`:
 
-### zsh
-
-Place this in `.zshrc`, update current `$PROMPT/$PS1` to `BASE_PROMPT`
-
-```zsh
-BASE_PROMPT=$PS1/$PROMPT
-PROMPT="${ZMX_SESSION:+[$ZMX_SESSION]} $BASE_PROMPT"
+```bash
+if [[ -n $ZMX_SESSION ]]; then
+  export PS1="[$ZMX_SESSION] ${PS1}"
+fi
 ```
 
 ## philosophy


### PR DESCRIPTION
I noticed the todo on the instructions for updating bash prompts. This commit combines both the zsh and the bash instructions in a generic setup. It also removes the leading space that you get with zsh when not in zmx. Just an idea in case it helps.

Unrelated, but this is a great project! Thank you for building it.