### PR TITLE
docs: Fix typo in feature list on index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
       <li>Persist terminal shell sessions (pty processes)</li>
       <li>Ability to attach and detach from a shell session without killing it</li>
       <li>Native terminal scrollback</li>
-      <li>Mlitiple clients can connect to the same session</li>
+      <li>Multiple clients can connect to the same session</li>
       <li>Re-attaching to a session restores previous terminal state and output</li>
       <li>Works on mac and linux</li>
       <li>This project does NOT provide windows, tabs, or splits</li>


### PR DESCRIPTION
Replace mistyped `Mlitiple` with `Mutliple`. 