### PR TITLE
chore: update ghostty to HEAD

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
     // internet connectivity.
     .dependencies = .{
         .ghostty = .{
-            .url = "git+https://github.com/ghostty-org/ghostty.git?ref=HEAD#a692cb9e5fabfd337827cc99cd62e3ea90ab9c92",
-            .hash = "ghostty-1.3.0-dev-5UdBC6t6RATdaEoNBRRIcMy7CBVNE0ih4NsX7btHlQek",
+            .url = "git+https://github.com/ghostty-org/ghostty.git?ref=HEAD#2868677af50af301ebe4ec1c7f79ad31dcd67cd3",
+            .hash = "ghostty-1.3.0-dev-5UdBC3gyTQRQT7y422Zu1H0zppGvkWLTVFPYuuTHxsKS",
         },
     },
     .paths = .{


### PR DESCRIPTION
## Bug
`zmx` was pinned to a Ghostty revision that could panic when parsing malformed OSC 133 prompt metadata (key with no `=`).

In practice this showed up as a daemon panic after attach/run when prompt markers were emitted, with an out-of-bounds slice in Ghostty OSC 133 parsing.

## Repro (before this PR)
1. Build/install zmx on the old pin.
2. Create a session and send a malformed OSC 133 sequence with a bare key:
   - `zmx run ghostty-osc /bin/sh`
   - `zmx run ghostty-osc "printf '\033]133;A;barekey\007\n'"`
3. Send another command (or attach and run first command).
4. Observe panic in the daemon path that feeds `ghostty-vt`.

## Fix
- Update `build.zig.zon` to latest Ghostty `main` (`2868677af50af301ebe4ec1c7f79ad31dcd67cd3`).
- Refresh dependency hash for that revision.

This pulls in the upstream Ghostty fix for OSC 133 bare-key handling:
- https://github.com/ghostty-org/ghostty/pull/10380 (merged)
- Related issue: https://github.com/ghostty-org/ghostty/issues/10379

## Validation
- `ZIG_GLOBAL_CACHE_DIR=/var/home/wegel/.cache/zig zig build -Doptimize=ReleaseSafe --prefix ~/.local`
- `ZIG_GLOBAL_CACHE_DIR=/var/home/wegel/.cache/zig zig build test`
- `ZIG_GLOBAL_CACHE_DIR=/var/home/wegel/.cache/zig zig build check`
- Runtime smoke: sent `\x1b]133;A;barekey\x07` through a zmx session and confirmed no panic.
