### PR TITLE
docs: add zsm to community tools section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,3 +328,7 @@ dtach is a program written in C that emulates the detach feature of screen, whic
 | Auto-daemonize                 | ✓   | ✓      | ✓      | ✓     | ✓    |
 | Daemon per session             | ✓   | ✗      | ✓      | ✓     | ✗    |
 | Session listing                | ✓   | ✓      | ✓      | ✗     | ✓    |
+
+## community tools
+
+- [zsm](https://github.com/mdsakalu/zmx-session-manager) — TUI session manager for zmx. List, preview, filter, and kill sessions from an interactive terminal UI.


### PR DESCRIPTION
## Summary
- Adds a "community tools" section to the README linking to [zsm](https://github.com/mdsakalu/zmx-session-manager), a TUI session manager for zmx

Per the suggestion in #54 — zsm provides an interactive terminal UI for listing, previewing, filtering, and managing zmx sessions.

Closes #54