### PR TITLE
docs: add zmosh to community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,3 +355,4 @@ dtach is a program written in C that emulates the detach feature of screen, whic
 ## community tools
 
 - [zsm](https://github.com/mdsakalu/zmx-session-manager) — TUI session manager for zmx. List, preview, filter, and kill sessions from an interactive terminal UI.
+- [zmosh](https://github.com/mmonad/zmosh) — A fork of zmx that adds encrypted UDP auto-reconnect for remote sessions (like mosh).


### PR DESCRIPTION
Hey neurosnap! First off, just want to say huge thanks for zmx. The architecture is brilliant—especially the decision to keep the daemon simple and use libghostty-vt. It made building zmosh a breeze.

I've been working on a fork called zmosh that takes zmx and adds encrypted UDP auto-reconnect (like mosh/ET) for flaky remote connections. It uses your exact daemon/session logic but wraps the client transport in XChaCha20-Poly1305.

Thought I'd add a link to it in the community tools section in case anyone else needs the roaming capability. Thanks again for the solid base!