### PR TITLE
fix(terminal): pop Kitty keyboard protocol on detach

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -936,6 +936,9 @@ fn attach(daemon: *Daemon) !void {
         // want to corrupt any programs that rely on it including ghostty's session restore.
         const restore_seq = "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" ++
             "\x1b[?2004l\x1b[?1004l\x1b[?1049l" ++
+            // Restore pre-attach Kitty keyboard protocol mode so Ctrl combos
+            // return to legacy encoding in the user's outer shell.
+            "\x1b[<u" ++
             "\x1b[?25h";
         _ = posix.write(posix.STDOUT_FILENO, restore_seq) catch {};
     }


### PR DESCRIPTION
## Problem

Inner session programs (e.g. Neovim, fish shell integration) can push Kitty keyboard protocol modes via escape sequences that zmx forwards to the outer terminal. Without a corresponding pop on detach, the outer terminal's keyboard stack stays in the pushed state — breaking Ctrl combo encoding in the outer shell after detaching.

For example, after detaching from a session where Neovim was open, `Ctrl+C` in the outer shell could arrive as `\x1b[99;5u` instead of `\x03`.

## Fix

Add `\x1b[<u` (Kitty protocol stack pop) to the terminal restore sequence in the local attach cleanup path.

Per the [Kitty keyboard protocol spec](https://sw.kovidgoyal.net/kitty/keyboard-protocol/#progressive-enhancement), popping an empty stack is a no-op, so this is safe when no push occurred during the session.