### PR TITLE
Update fish shell instructions to use user completions directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ fi
 
 ### fish
 
-Add this to your `~/.config/fish/completions/zmx.fish` file:
+Add this to `~/.config/fish/completions/zmx.fish`:
 
 ```fish
 if type -q zmx


### PR DESCRIPTION
According to https://fishshell.com/docs/current/completions.html#where-to-put-completions, user-written completions (which I guess is the right place, since these aren't auto-installed) should go in `~/.config/fish/completions/`.