### PR TITLE
Add openSUSE Tumbleweed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ brew install neurosnap/tap/zmx
 - [Alpine Linux](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zmx)
 - [Arch AUR tracking releases](https://aur.archlinux.org/packages/zmx)
 - [Arch AUR tracking git](https://aur.archlinux.org/packages/zmx-git)
+- [openSUSE Tumbleweed](https://software.opensuse.org/package/zmx)
 
 ### src
 


### PR DESCRIPTION
Hi @neurosnap!

First, awesome and really useful tool! It provides almost everything I need for session persistence without using Zellij or Tmux.

As I work in multiplatform environments and one of them is openSUSE — honestly since very recently — I decided to learn to build an openSUSE package using zmx as the target.

At the moment it is not available in the main repositories (`openSUSE:Factory`), but it is possible to install it from my personal space on OBS. It is only available for openSUSE Tumbleweed, the distribution I specifically use.

I added to the README.md a link to the software center of openSUSE (I have to upload the zmx logo yet), where if you click "Show Community Packages" you will see zmx on `home:ivanhercaz`.

More information is available in:

- The `zmx-spec` repository: <https://codeberg.org/ivanhercaz/zmx-spec>
- The package on OBS: <https://build.opensuse.org/package/show/home:ivanhercaz/zmx>

As I mentioned before, this is my first openSUSE package so I will keep an eye out for any issues or improvements needed. Once I read a bit more about the openSUSE packaging ecosystem, I will try to move to the next phase.

Thanks for this great tool!