### PR TITLE
More bugfixes

### DIFF
--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -15,6 +15,10 @@ pub const Tag = enum(u8) {
     History = 8,
     Run = 9,
     Ack = 10,
+    // Non-exhaustive: this enum comes off the wire via bytesToValue and
+    // @enumFromInt, so out-of-range values (11-255) are representable
+    // rather than UB. Switches must handle `_` (unknown tag).
+    _,
 };
 
 pub const Header = packed struct {
@@ -53,7 +57,9 @@ pub const Info = extern struct {
 pub fn expectedLength(data: []const u8) ?usize {
     if (data.len < @sizeOf(Header)) return null;
     const header = std.mem.bytesToValue(Header, data[0..@sizeOf(Header)]);
-    return @sizeOf(Header) + header.len;
+    // header.len comes off the wire; widen to usize before adding so a
+    // near-u32-max value can't wrap (panic in safe mode, UB in release).
+    return @as(usize, @sizeOf(Header)) + @as(usize, header.len);
 }
 
 pub fn send(fd: i32, tag: Tag, data: []const u8) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -652,6 +652,7 @@ fn wait(cfg: *Cfg, session_names: std.ArrayList([]const u8)) !void {
     // appeared yet" (keep polling) from "sessions we were tracking
     // disappeared" (fail — daemon crashed or was killed).
     var max_seen: i32 = 0;
+    var zero_match_iters: u32 = 0;
 
     while (true) {
         var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
@@ -704,6 +705,20 @@ fn wait(cfg: *Cfg, session_names: std.ArrayList([]const u8)) !void {
             try stdout.flush();
             std.process.exit(agg_exit_code);
             return;
+        }
+
+        if (max_seen == 0) {
+            // `zmx run foo && zmx wait foo` is essentially sequential, so
+            // matching sessions should be visible from the first poll. If
+            // nothing appears after a few iterations it's almost certainly a
+            // typo, not a slow start.
+            zero_match_iters += 1;
+            if (zero_match_iters >= 3) {
+                try stdout.print("error: no matching sessions found\n", .{});
+                try stdout.flush();
+                std.process.exit(2);
+                return;
+            }
         }
 
         std.Thread.sleep(1000 * std.time.ns_per_ms);

--- a/src/main.zig
+++ b/src/main.zig
@@ -490,15 +490,6 @@ const Daemon = struct {
 
         const resize = std.mem.bytesToValue(ipc.Resize, payload);
 
-        var ws: cross.c.struct_winsize = .{
-            .ws_row = resize.rows,
-            .ws_col = resize.cols,
-            .ws_xpixel = 0,
-            .ws_ypixel = 0,
-        };
-        _ = cross.c.ioctl(pty_fd, cross.c.TIOCSWINSZ, &ws);
-        try term.resize(self.alloc, resize.cols, resize.rows);
-
         // Serialize terminal state BEFORE resize to capture correct cursor position.
         // Resizing triggers reflow which can move the cursor, and the shell's
         // SIGWINCH-triggered redraw will run after our snapshot is sent.
@@ -516,6 +507,15 @@ const Daemon = struct {
                 client.has_pending_output = true;
             }
         }
+
+        var ws: cross.c.struct_winsize = .{
+            .ws_row = resize.rows,
+            .ws_col = resize.cols,
+            .ws_xpixel = 0,
+            .ws_ypixel = 0,
+        };
+        _ = cross.c.ioctl(pty_fd, cross.c.TIOCSWINSZ, &ws);
+        try term.resize(self.alloc, resize.cols, resize.rows);
 
         // Mark that we've had a client init, so subsequent clients get terminal state
         self.has_had_client = true;

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,6 +33,11 @@ fn zmxLogFn(
 var sigwinch_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var sigterm_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 
+// Platform-correct O_NONBLOCK bit for fcntl(F_SETFL).
+// posix.O is a packed struct; bitcasting a zero-initialized struct with
+// NONBLOCK=true gives 0x800 on Linux, 0x4 on macOS, etc.
+const O_NONBLOCK: u32 = @bitCast(posix.O{ .NONBLOCK = true });
+
 pub fn main() !void {
     // use c_allocator to avoid "reached unreachable code" panic in DebugAllocator when forking
     const alloc = std.heap.c_allocator;
@@ -334,7 +339,7 @@ const Daemon = struct {
 
         // make pty non-blocking
         const flags = try posix.fcntl(master_fd, posix.F.GETFL, 0);
-        _ = try posix.fcntl(master_fd, posix.F.SETFL, flags | @as(u32, 0o4000));
+        _ = try posix.fcntl(master_fd, posix.F.SETFL, flags | O_NONBLOCK);
         return master_fd;
     }
 
@@ -372,22 +377,27 @@ const Daemon = struct {
                 defer self.alloc.free(session_log_path);
                 try log_system.init(self.alloc, session_log_path);
 
-                errdefer {
+                // If spawnPty fails, clean up here. Once it succeeds,
+                // the inner block's defer takes ownership of cleanup to
+                // avoid double-closing server_sock_fd on daemonLoop error.
+                const pty_fd = self.spawnPty() catch |err| {
                     posix.close(server_sock_fd);
                     dir.deleteFile(self.session_name) catch {};
+                    return err;
+                };
+                {
+                    defer {
+                        self.handleKill();
+                        _ = posix.waitpid(self.pid, 0);
+                        posix.close(pty_fd);
+                        posix.close(server_sock_fd);
+                        std.log.info("deleting socket file session_name={s}", .{self.session_name});
+                        dir.deleteFile(self.session_name) catch |err| {
+                            std.log.warn("failed to delete socket file err={s}", .{@errorName(err)});
+                        };
+                    }
+                    try daemonLoop(self, server_sock_fd, pty_fd);
                 }
-                const pty_fd = try self.spawnPty();
-                defer {
-                    posix.close(pty_fd);
-                    posix.close(server_sock_fd);
-                    std.log.info("deleting socket file session_name={s}", .{self.session_name});
-                    dir.deleteFile(self.session_name) catch |err| {
-                        std.log.warn("failed to delete socket file err={s}", .{@errorName(err)});
-                    };
-                }
-                try daemonLoop(self, server_sock_fd, pty_fd);
-                self.handleKill();
-                _ = posix.waitpid(self.pid, 0);
                 self.deinit();
                 return .{ .created = true, .is_daemon = true };
             }
@@ -399,10 +409,33 @@ const Daemon = struct {
         return .{ .created = false, .is_daemon = false };
     }
 
-    pub fn handleInput(self: *Daemon, pty_fd: i32, payload: []const u8) !void {
+    /// Best-effort write to the (non-blocking) PTY fd. Retries short writes
+    /// until complete, but on WouldBlock (kernel buffer full) gives up and
+    /// drops the remainder — the daemon is single-threaded, so blocking here
+    /// to wait for POLLOUT would deadlock against a shell that's itself
+    /// blocked writing echo to a full PTY output buffer that we're not
+    /// draining. Dropping is the same trade-off the old code made implicitly
+    /// (short writes were silently truncated), just without the crash.
+    fn ptyWrite(pty_fd: i32, data: []const u8) void {
+        var remaining = data;
+        while (remaining.len > 0) {
+            const n = posix.write(pty_fd, remaining) catch |err| {
+                if (err == error.WouldBlock) {
+                    std.log.warn("pty write dropped {d}/{d} bytes (buffer full)", .{ remaining.len, data.len });
+                } else {
+                    std.log.warn("pty write failed, {d} bytes lost: {s}", .{ remaining.len, @errorName(err) });
+                }
+                return;
+            };
+            if (n == 0) return;
+            remaining = remaining[n..];
+        }
+    }
+
+    pub fn handleInput(self: *Daemon, pty_fd: i32, payload: []const u8) void {
         _ = self;
         if (payload.len > 0) {
-            _ = try posix.write(pty_fd, payload);
+            ptyWrite(pty_fd, payload);
         }
     }
 
@@ -575,7 +608,7 @@ const Daemon = struct {
         self.is_task_mode = true;
 
         if (payload.len > 0) {
-            _ = try posix.write(pty_fd, payload);
+            ptyWrite(pty_fd, payload);
         }
         try ipc.appendMessage(self.alloc, &client.write_buf, .Ack, "");
         client.has_pending_output = true;
@@ -1072,7 +1105,7 @@ fn clientLoop(client_sock_fd: i32) !void {
 
     // Make socket non-blocking to avoid blocking on writes
     const sock_flags = try posix.fcntl(client_sock_fd, posix.F.GETFL, 0);
-    _ = try posix.fcntl(client_sock_fd, posix.F.SETFL, sock_flags | posix.SOCK.NONBLOCK);
+    _ = try posix.fcntl(client_sock_fd, posix.F.SETFL, sock_flags | O_NONBLOCK);
 
     // Buffer for outgoing socket writes
     var sock_write_buf = try std.ArrayList(u8).initCapacity(alloc, 4096);
@@ -1093,9 +1126,12 @@ fn clientLoop(client_sock_fd: i32) !void {
 
     const stdin_fd = posix.STDIN_FILENO;
 
-    // Make stdin non-blocking
-    const flags = try posix.fcntl(stdin_fd, posix.F.GETFL, 0);
-    _ = try posix.fcntl(stdin_fd, posix.F.SETFL, flags | posix.SOCK.NONBLOCK);
+    // Make stdin non-blocking. O_NONBLOCK is set on the open file description,
+    // which is shared with the parent shell; restore on exit to avoid
+    // corrupting the parent's stdin.
+    const stdin_orig_flags = try posix.fcntl(stdin_fd, posix.F.GETFL, 0);
+    _ = try posix.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags | O_NONBLOCK);
+    defer _ = posix.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags) catch {};
 
     while (true) {
         // Check for pending SIGWINCH
@@ -1369,7 +1405,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
 
                 while (client.read_buf.next()) |msg| {
                     switch (msg.header.tag) {
-                        .Input => try daemon.handleInput(pty_fd, msg.payload),
+                        .Input => daemon.handleInput(pty_fd, msg.payload),
                         .Init => try daemon.handleInit(client, pty_fd, &term, msg.payload),
                         .Resize => try daemon.handleResize(pty_fd, &term, msg.payload),
                         .Detach => {

--- a/src/main.zig
+++ b/src/main.zig
@@ -362,9 +362,18 @@ const Daemon = struct {
                 if (self.command != null) {
                     std.log.warn("session already exists, ignoring command session={s}", .{self.session_name});
                 }
-            } else |_| {
-                socket.cleanupStaleSocket(dir, self.session_name);
-                should_create = true;
+            } else |err| switch (err) {
+                // Daemon is definitively gone: safe to replace.
+                error.ConnectionRefused => {
+                    socket.cleanupStaleSocket(dir, self.session_name);
+                    should_create = true;
+                },
+                // Probe didn't respond in time — daemon may just be busy.
+                // The probe is only to decide create-vs-attach; the session
+                // exists, so proceed to attach rather than fail or orphan.
+                else => {
+                    std.log.warn("probe slow ({s}), proceeding to attach session={s}", .{ @errorName(err), self.session_name });
+                },
             }
         }
 
@@ -712,6 +721,17 @@ fn wait(cfg: *Cfg, session_names: std.ArrayList([]const u8)) !void {
             }
 
             total += 1;
+            if (session.is_error) {
+                // Daemon unreachable (probe timed out). On Timeout the socket
+                // is no longer deleted, so this session would otherwise
+                // persist as task_ended_at==0 forever → infinite "still
+                // waiting". Count it as done+failed so wait terminates.
+                try stdout.print("task unreachable: {s} ({s})\n", .{ session.name, session.error_name orelse "unknown" });
+                try stdout.flush();
+                agg_exit_code = 1;
+                done += 1;
+                continue;
+            }
             if (session.task_ended_at == 0) {
                 try stdout.print("still waiting task={s}\n", .{session.name});
                 try stdout.flush();
@@ -820,7 +840,7 @@ fn detachAll(cfg: *Cfg) !void {
     defer alloc.free(socket_path);
     const result = ipc.probeSession(alloc, socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
-        socket.cleanupStaleSocket(dir, session_name);
+        if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, session_name);
         return;
     };
     defer posix.close(result.fd);
@@ -848,10 +868,14 @@ fn kill(cfg: *Cfg, session_name: []const u8) !void {
     defer alloc.free(socket_path);
     const result = ipc.probeSession(alloc, socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
-        socket.cleanupStaleSocket(dir, session_name);
         var buf: [4096]u8 = undefined;
         var w = std.fs.File.stdout().writer(&buf);
-        w.interface.print("cleaned up stale session {s}\n", .{session_name}) catch {};
+        if (err == error.ConnectionRefused) {
+            socket.cleanupStaleSocket(dir, session_name);
+            w.interface.print("cleaned up stale session {s}\n", .{session_name}) catch {};
+        } else {
+            w.interface.print("session {s} is unresponsive ({s}) — daemon may be busy, try again or kill the process directly\n", .{ session_name, @errorName(err) }) catch {};
+        }
         w.interface.flush() catch {};
         return;
     };
@@ -885,7 +909,7 @@ fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !voi
     defer alloc.free(socket_path);
     const result = ipc.probeSession(alloc, socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
-        socket.cleanupStaleSocket(dir, session_name);
+        if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, session_name);
         return;
     };
     defer posix.close(result.fd);

--- a/src/main.zig
+++ b/src/main.zig
@@ -983,13 +983,19 @@ fn attach(daemon: *Daemon) !void {
     //      - modify the desired attributes in the termios structure
     //      - then apply the changes with tcsetattr().
     //  This prevents unintended side effects by preserving other settings.
-    var orig_termios: cross.c.termios = undefined;
-    _ = cross.c.tcgetattr(posix.STDIN_FILENO, &orig_termios);
-
     // restore stdin fd to its original state after exiting.
     // Use TCSAFLUSH to discard any unread input, preventing stale input after detach.
+    //
+    // tcgetattr fails when stdin is not a TTY (e.g. piped). In that case,
+    // skip terminal setup entirely rather than applying undefined stack bytes
+    // via tcsetattr.
+    var orig_termios: cross.c.termios = undefined;
+    const stdin_is_tty = cross.c.tcgetattr(posix.STDIN_FILENO, &orig_termios) == 0;
+
     defer {
-        _ = cross.c.tcsetattr(posix.STDIN_FILENO, cross.c.TCSAFLUSH, &orig_termios);
+        if (stdin_is_tty) {
+            _ = cross.c.tcsetattr(posix.STDIN_FILENO, cross.c.TCSAFLUSH, &orig_termios);
+        }
         // Reset terminal modes on detach:
         // - Mouse: 1000=basic, 1002=button-event, 1003=any-event, 1006=SGR extended
         // - 2004=bracketed paste, 1004=focus events, 1049=alt screen
@@ -1005,21 +1011,23 @@ fn attach(daemon: *Daemon) !void {
         _ = posix.write(posix.STDOUT_FILENO, restore_seq) catch {};
     }
 
-    var raw_termios = orig_termios;
-    //  set raw mode after successful connection.
-    //      disables canonical mode (line buffering), input echoing, signal generation from
-    //      control characters (like Ctrl+C), and flow control.
-    cross.c.cfmakeraw(&raw_termios);
+    if (stdin_is_tty) {
+        var raw_termios = orig_termios;
+        //  set raw mode after successful connection.
+        //      disables canonical mode (line buffering), input echoing, signal generation from
+        //      control characters (like Ctrl+C), and flow control.
+        cross.c.cfmakeraw(&raw_termios);
 
-    // Additional granular raw mode settings for precise control
-    // (matches what abduco and shpool do)
-    raw_termios.c_cc[cross.c.VLNEXT] = cross.c._POSIX_VDISABLE; // Disable literal-next (Ctrl-V)
-    // We want to intercept Ctrl+\ (SIGQUIT) so we can use it as a detach key
-    raw_termios.c_cc[cross.c.VQUIT] = cross.c._POSIX_VDISABLE; // Disable SIGQUIT (Ctrl+\)
-    raw_termios.c_cc[cross.c.VMIN] = 1; // Minimum chars to read: return after 1 byte
-    raw_termios.c_cc[cross.c.VTIME] = 0; // Read timeout: no timeout, return immediately
+        // Additional granular raw mode settings for precise control
+        // (matches what abduco and shpool do)
+        raw_termios.c_cc[cross.c.VLNEXT] = cross.c._POSIX_VDISABLE; // Disable literal-next (Ctrl-V)
+        // We want to intercept Ctrl+\ (SIGQUIT) so we can use it as a detach key
+        raw_termios.c_cc[cross.c.VQUIT] = cross.c._POSIX_VDISABLE; // Disable SIGQUIT (Ctrl+\)
+        raw_termios.c_cc[cross.c.VMIN] = 1; // Minimum chars to read: return after 1 byte
+        raw_termios.c_cc[cross.c.VTIME] = 0; // Read timeout: no timeout, return immediately
 
-    _ = cross.c.tcsetattr(posix.STDIN_FILENO, cross.c.TCSANOW, &raw_termios);
+        _ = cross.c.tcsetattr(posix.STDIN_FILENO, cross.c.TCSANOW, &raw_termios);
+    }
 
     // Clear screen before attaching. This provides a clean slate before
     // the session restore.

--- a/src/main.zig
+++ b/src/main.zig
@@ -626,7 +626,7 @@ const Daemon = struct {
 
     pub fn handleHistory(self: *Daemon, client: *Client, term: *ghostty_vt.Terminal, payload: []const u8) !void {
         const format: util.HistoryFormat = if (payload.len > 0)
-            @enumFromInt(payload[0])
+            std.meta.intToEnum(util.HistoryFormat, payload[0]) catch .plain
         else
             .plain;
         if (util.serializeTerminal(self.alloc, term, format)) |output| {
@@ -1487,6 +1487,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                         .History => try daemon.handleHistory(client, &term, msg.payload),
                         .Run => try daemon.handleRun(client, pty_fd, msg.payload),
                         .Output, .Ack => {},
+                        _ => std.log.warn("ignoring unknown IPC tag={d}", .{@intFromEnum(msg.header.tag)}),
                     }
                 }
             }

--- a/src/main.zig
+++ b/src/main.zig
@@ -296,6 +296,48 @@ const Daemon = struct {
         return false;
     }
 
+    /// Runs in the forked child. Either execs or returns an error (caller
+    /// must exit on error — returning would fall through to parent code).
+    fn execChild(self: *Daemon) !noreturn {
+        const alloc = std.heap.c_allocator;
+
+        // main() set SIGPIPE to SIG_IGN, which (unlike handlers) survives
+        // exec. Restore the default so the shell and its children behave
+        // normally (e.g. `yes | head` should exit 141 via SIGPIPE).
+        const dfl: posix.Sigaction = .{
+            .handler = .{ .handler = posix.SIG.DFL },
+            .mask = posix.sigemptyset(),
+            .flags = 0,
+        };
+        posix.sigaction(posix.SIG.PIPE, &dfl, null);
+
+        const session_env = try std.fmt.allocPrintSentinel(
+            alloc,
+            "ZMX_SESSION={s}",
+            .{self.session_name},
+            0,
+        );
+        _ = cross.c.putenv(session_env.ptr);
+
+        if (self.command) |cmd_args| {
+            const argv = try alloc.allocSentinel(?[*:0]const u8, cmd_args.len, null);
+            for (cmd_args, 0..) |arg, i| {
+                argv[i] = try alloc.dupeZ(u8, arg);
+            }
+            const err = std.posix.execvpeZ(argv[0].?, argv.ptr, std.c.environ);
+            std.log.err("execvpe failed: cmd={s} err={s}", .{ cmd_args[0], @errorName(err) });
+            std.posix.exit(1);
+        }
+
+        const shell = util.detectShell();
+        // Use "-shellname" as argv[0] to signal login shell (traditional method)
+        const login_shell = try std.fmt.allocPrintSentinel(alloc, "-{s}", .{std.fs.path.basename(shell)}, 0);
+        const argv = [_:null]?[*:0]const u8{ login_shell, null };
+        const err = std.posix.execveZ(shell, &argv, std.c.environ);
+        std.log.err("execve failed: err={s}", .{@errorName(err)});
+        std.posix.exit(1);
+    }
+
     fn spawnPty(self: *Daemon) !c_int {
         const size = ipc.getTerminalSize(posix.STDOUT_FILENO);
         var ws: cross.c.struct_winsize = .{
@@ -312,32 +354,15 @@ const Daemon = struct {
         }
 
         if (pid == 0) { // child pid code path
-            const session_env = try std.fmt.allocPrint(self.alloc, "ZMX_SESSION={s}\x00", .{self.session_name});
-            _ = cross.c.putenv(@ptrCast(session_env.ptr));
-
-            if (self.command) |cmd_args| {
-                const alloc = std.heap.c_allocator;
-                var argv_buf: [64:null]?[*:0]const u8 = undefined;
-                for (cmd_args, 0..) |arg, i| {
-                    argv_buf[i] = alloc.dupeZ(u8, arg) catch {
-                        std.posix.exit(1);
-                    };
-                }
-                argv_buf[cmd_args.len] = null;
-                const argv: [*:null]const ?[*:0]const u8 = &argv_buf;
-                const err = std.posix.execvpeZ(argv_buf[0].?, argv, std.c.environ);
-                std.log.err("execvpe failed: cmd={s} err={s}", .{ cmd_args[0], @errorName(err) });
+            // In the forked child, ANY error must exit rather than propagate:
+            // a returned error falls through to the parent code path below,
+            // running a second daemon on the same socket (or worse, hitting
+            // errdefers that delete the parent's socket file).
+            execChild(self) catch |err| {
+                std.log.err("child setup failed: {s}", .{@errorName(err)});
                 std.posix.exit(1);
-            } else {
-                const shell = util.detectShell();
-                // Use "-shellname" as argv[0] to signal login shell (traditional method)
-                var buf: [64]u8 = undefined;
-                const login_shell = try std.fmt.bufPrintZ(&buf, "-{s}", .{std.fs.path.basename(shell)});
-                const argv = [_:null]?[*:0]const u8{ login_shell, null };
-                const err = std.posix.execveZ(shell, &argv, std.c.environ);
-                std.log.err("execve failed: err={s}", .{@errorName(err)});
-                std.posix.exit(1);
-            }
+            };
+            unreachable; // execChild either execs or exits, never returns ok
         }
         // master pid code path
         self.pid = pid;

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,6 +42,12 @@ pub fn main() !void {
     // use c_allocator to avoid "reached unreachable code" panic in DebugAllocator when forking
     const alloc = std.heap.c_allocator;
 
+    // Every subcommand may write to a Unix-domain socket; a peer that
+    // disappears between probe and send would otherwise kill us before
+    // write() can return BrokenPipe. Inherited across fork, so this also
+    // covers the daemon.
+    ignoreSigpipe();
+
     var args = try std.process.argsWithAllocator(alloc);
     defer args.deinit();
     _ = args.skip(); // skip program name
@@ -1302,6 +1308,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
         }
 
         _ = posix.poll(poll_fds.items, -1) catch |err| {
+            if (err == error.Interrupted) continue;
             return err;
         };
 
@@ -1462,6 +1469,9 @@ fn handleSigterm(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c)
     sigterm_received.store(true, .release);
 }
 
+// No SA_RESTART on these: we WANT the signal to interrupt poll() so the
+// loop can check the flag. On BSD/macOS, SA_RESTART makes poll restartable,
+// which would leave an idle daemon deaf to SIGTERM until other I/O wakes it.
 fn setupSigwinchHandler() void {
     const act: posix.Sigaction = .{
         .handler = .{ .sigaction = handleSigwinch },
@@ -1478,4 +1488,13 @@ fn setupSigtermHandler() void {
         .flags = posix.SA.SIGINFO,
     };
     posix.sigaction(posix.SIG.TERM, &act, null);
+}
+
+fn ignoreSigpipe() void {
+    const act: posix.Sigaction = .{
+        .handler = .{ .handler = posix.SIG.IGN },
+        .mask = posix.sigemptyset(),
+        .flags = 0,
+    };
+    posix.sigaction(posix.SIG.PIPE, &act, null);
 }

--- a/src/util.zig
+++ b/src/util.zig
@@ -64,13 +64,16 @@ pub fn get_session_entries(alloc: std.mem.Allocator, socket_dir: []const u8) !st
             };
             posix.close(result.fd);
 
-            // Extract cmd and cwd from the fixed-size arrays
-            const cmd: ?[]const u8 = if (result.info.cmd_len > 0)
-                alloc.dupe(u8, result.info.cmd[0..result.info.cmd_len]) catch null
+            // Extract cmd and cwd from the fixed-size arrays. Lengths come
+            // off the wire (u16 range), so clamp to the actual array size.
+            const cmd_len = @min(result.info.cmd_len, ipc.MAX_CMD_LEN);
+            const cwd_len = @min(result.info.cwd_len, ipc.MAX_CWD_LEN);
+            const cmd: ?[]const u8 = if (cmd_len > 0)
+                alloc.dupe(u8, result.info.cmd[0..cmd_len]) catch null
             else
                 null;
-            const cwd: ?[]const u8 = if (result.info.cwd_len > 0)
-                alloc.dupe(u8, result.info.cwd[0..result.info.cwd_len]) catch null
+            const cwd: ?[]const u8 = if (cwd_len > 0)
+                alloc.dupe(u8, result.info.cwd[0..cwd_len]) catch null
             else
                 null;
 

--- a/src/util.zig
+++ b/src/util.zig
@@ -54,7 +54,12 @@ pub fn get_session_entries(alloc: std.mem.Allocator, socket_dir: []const u8) !st
                     .task_exit_code = 1,
                     .task_ended_at = 0,
                 });
-                socket.cleanupStaleSocket(dir, entry.name);
+                // Only clean up when the daemon is definitively gone. A busy
+                // daemon can miss the probe timeout; deleting its socket
+                // orphans it permanently.
+                if (err == error.ConnectionRefused) {
+                    socket.cleanupStaleSocket(dir, entry.name);
+                }
                 continue;
             };
             posix.close(result.fd);
@@ -292,10 +297,18 @@ pub fn writeSessionLine(writer: *std.Io.Writer, session: SessionEntry, short: bo
     }
 
     if (session.is_error) {
-        try writer.print("{s}name={s}\terr={s}\tstatus=cleaning up\n", .{
+        // "cleaning up" is only truthful when the probe was definitively
+        // refused (socket deleted this pass). On Timeout/Unexpected the
+        // daemon may just be busy, so don't lie about what we did.
+        const status = if (std.mem.eql(u8, session.error_name.?, "ConnectionRefused"))
+            "cleaning up"
+        else
+            "unreachable";
+        try writer.print("{s}name={s}\terr={s}\tstatus={s}\n", .{
             prefix,
             session.name,
             session.error_name.?,
+            status,
         });
         return;
     }


### PR DESCRIPTION
Follow-up to #83. 8 more fixes — mostly defensive (the code is demonstrably wrong but you won't hit it in normal use). One actual improvement to `wait`.

There's also a follow-up PR with a Go e2e test harness that exercises a few of these.

---

### `wait` times out instead of polling forever (`src/main.zig:720`)

#83 added the `total > 0` guard so `wait` wouldn't exit 0 when nothing matches. But that just made it poll forever on a typo. Now after ~3s with no matches it exits 2 with "no matching sessions found". 3s is plenty since `run foo && wait foo` is sequential.

---

### Wrong O_NONBLOCK constants + the bugs that hid behind them (`src/main.zig:336,...`)

`0o4000` is the Linux value — on macOS that's `O_EXCL`, which `F_SETFL` just drops. Same for `posix.SOCK.NONBLOCK` (Zig defines it as `0x10000` on darwin for API consistency, but it's not a file-status flag). So on macOS the PTY/socket/stdin were never actually non-blocking. Nothing visibly broke because `poll()` guards every read, but it meant the `WouldBlock` paths were dead code on one of our two platforms.

Verified via `sys/fcntl.h` on macOS 26.3.1 + a C test program that shows `F_SETFL` silently drops both bogus bits.

Fixing this exposed three things that were only working by accident:
- `handleInput`/`handleRun` did `_ = try posix.write(...)` — short writes dropped bytes, `WouldBlock` crashed the daemon. New `ptyWrite()` retries short writes and logs+drops on `WouldBlock` (matches old behavior, just explicit).
- `ensureSession` had both an `errdefer` and a `defer` closing the same fd → double-close → `EBADF` unreachable in safe builds when daemonLoop errored.
- `daemonLoop` error skipped the `handleKill`/`waitpid` that sits below it → orphaned shell. Moved those into the defer.

Also: stdin's O_NONBLOCK lives on the open file description (shared with the parent shell), so we save/restore flags.

---

### SIGPIPE + EINTR handling (`src/main.zig:1349,1223`)

SIGPIPE's default is terminate, and it fires *before* `write()` gets to return `BrokenPipe`. So an abruptly exiting client could kill the daemon. `ignoreSigpipe()` in `main()` fixes it (inherited across fork). The SIG_IGN is restored to SIG_DFL before exec so `yes | head` inside a session still exits 141.

Daemon's poll loop didn't handle EINTR — SIGTERM made it error out instead of checking the flag and exiting cleanly. Fixed.

Deliberately *not* setting `SA_RESTART` on the handlers: on BSD/macOS `poll()` is restartable with that flag, so an idle daemon would never wake up to check the sigterm flag.

---

### Stale-socket cleanup on Timeout orphans busy daemons (`src/util.zig:46`, ...)

The 1s probe timeout can fire on a daemon that's just busy (heavy output, resize reflow). Deleting its socket orphans it forever. Now only `ConnectionRefused` triggers cleanup. `zmx list` now says `status=unreachable` instead of the misleading `cleaning up`. `zmx wait` treats unreachable sessions as done+failed so it doesn't loop forever.

---

### Fork-child can fall through to parent code path (`src/main.zig:303`)

`try` in the `pid == 0` branch could propagate an error past the if-block — the child then runs the parent code, maybe starting a second daemon or deleting the real one's socket via errdefer. The `bufPrintZ` case triggers with a `SHELL` basename >62 chars. There was also a fixed `argv_buf[64]` with no bounds check.

Extracted an `execChild()` returning `!noreturn` — it either execs or returns an error; caller exits on any error. Argv is heap-allocated now.

---

### `handleInit` serialize/resize order (`src/main.zig:426`)

Comment says "serialize BEFORE resize", code did the opposite. Resize triggers reflow which moves the cursor, so the snapshot had a stale cursor position. Swapped the order.

---

### Undefined termios with non-TTY stdin (`src/main.zig:860`)

`_ = tcgetattr(...)` discarded the error. With piped stdin it fails and `orig_termios` is stack garbage. Fixed by checking the return and skipping termios setup when stdin isn't a TTY.

---

### IPC wire data validation (`src/ipc.zig:53`, ...)

Stuff coming off the socket wasn't sanity-checked:
- `header.len` + `@sizeOf(Header)` could wrap on a near-u32-max value → widened to usize
- `cmd_len`/`cwd_len` used directly as slice bounds → clamped with `@min`
- `Tag` enum was exhaustive, so an out-of-range byte was UB → made non-exhaustive with `_` arm
- Same for `HistoryFormat` → `intToEnum catch .plain`
