### PR TITLE
fix: print error to stderr when session does not exist

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -883,8 +883,11 @@ fn kill(cfg: *Cfg, session_name: []const u8) !void {
 
     const exists = try socket.sessionExists(dir, session_name);
     if (!exists) {
-        std.log.err("cannot kill session because it does not exist session_name={s}", .{session_name});
-        return;
+        var buf: [4096]u8 = undefined;
+        var w = std.fs.File.stderr().writer(&buf);
+        w.interface.print("error: session \"{s}\" does not exist\n", .{session_name}) catch {};
+        w.interface.flush() catch {};
+        return error.SessionNotFound;
     }
 
     const socket_path = try socket.getSocketPath(alloc, cfg.socket_dir, session_name);
@@ -924,8 +927,11 @@ fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !voi
 
     const exists = try socket.sessionExists(dir, session_name);
     if (!exists) {
-        std.log.err("session does not exist session_name={s}", .{session_name});
-        return;
+        var buf: [4096]u8 = undefined;
+        var w = std.fs.File.stderr().writer(&buf);
+        w.interface.print("error: session \"{s}\" does not exist\n", .{session_name}) catch {};
+        w.interface.flush() catch {};
+        return error.SessionNotFound;
     }
 
     const socket_path = try socket.getSocketPath(alloc, cfg.socket_dir, session_name);


### PR DESCRIPTION
## Summary

`zmx kill` and `zmx history` silently return exit code 0 when given a non-existent session name. The error is only written to the log file via `std.log.err`, which is invisible to users.

**Before:**
```
$ zmx hi i-dont-exist
$ echo $?
0
```

**After:**
```
$ zmx hi i-dont-exist
error: session "i-dont-exist" does not exist
$ echo $?
1
```

Both `kill` and `history` now print a clear error to stderr and return a non-zero exit code when the session doesn't exist.

Fixes #68

## Breaking change note

This changes the exit code from 0 to non-zero when a session is not found. Scripts that check `$?` after `zmx kill` or `zmx history` may be affected — though arguably those scripts were already silently broken by treating a failed operation as success.

## Test plan

- [x] `zmx history nonexistent-session` prints error to stderr, exits non-zero
- [x] `zmx kill nonexistent-session` prints error to stderr, exits non-zero
- [x] Existing sessions still work normally