### PR TITLE
chore: add openSUSE package link to website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,6 +64,7 @@ brew install zmx</pre>
       <li><a href="https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zmx">Alpine Linux</a></li>
       <li><a href="https://aur.archlinux.org/packages/zmx">Arch AUR tracking releases</a></li>
       <li><a href="https://aur.archlinux.org/packages/zmx-git">Arch AUR tracking git</a></li>
+      <li><a href="https://software.opensuse.org/package/zmx">openSUSE Tumbleweed</a></li>
     </ul>
 
     <h2 class="text-lg">posts</h2>


### PR DESCRIPTION
Hi!

First, excuse me for this second pull request with only one line added. When I created the previous one (#79), I didn't see that the link to the package should be added to `docs/index.html` as well as to the `README.md`.

I'll take advantage of this PR to mention that, for the case of the openSUSE package, I want to be attentive and not miss version releases of zmx. So I created a zsh script to check it periodically. You can check it in the section ["Version monitoring" of `zmx-spec`](https://codeberg.org/ivanhercaz/zmx-spec#version-monitoring). I'm mentioning this just in case you think it may be of interest to some other maintainer (I can invite anyone interested to the Telegram channel, or even adapt it to other platforms if desired).

Regards