### PR TITLE
Refactor fish completions for zmx command

### DIFF
--- a/src/completions.zig
+++ b/src/completions.zig
@@ -118,22 +118,25 @@ const zsh_completions =
 const fish_completions =
     \\complete -c zmx -f
     \\
-    \\set -l subcommands attach run detach list completions kill history version help
-    \\set -l no_subcmd "not __fish_seen_subcommand_from $subcommands"
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'a attach' -d 'Attach to session, creating if needed'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'r run' -d 'Send command without attaching'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'd detach' -d 'Detach all clients from current session'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'l list' -d 'List active sessions'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'c completions' -d 'Shell completion scripts'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'k kill' -d 'Kill a session'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'hi history' -d 'Output session scrollback'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'v version' -d 'Show version'
+    \\complete -c zmx -s v -l version -d 'Show version'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'w wait' -d 'Wait for session tasks to complete'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'h help' -d 'Show help message'
+    \\complete -c zmx -s h -d 'Show help message'
     \\
-    \\complete -c zmx -n $no_subcmd -a attach -d 'Attach to session, creating if needed'
-    \\complete -c zmx -n $no_subcmd -a run -d 'Send command without attaching'
-    \\complete -c zmx -n $no_subcmd -a detach -d 'Detach all clients from current session'
-    \\complete -c zmx -n $no_subcmd -a list -d 'List active sessions'
-    \\complete -c zmx -n $no_subcmd -a completions -d 'Shell completion scripts'
-    \\complete -c zmx -n $no_subcmd -a kill -d 'Kill a session'
-    \\complete -c zmx -n $no_subcmd -a history -d 'Output session scrollback'
-    \\complete -c zmx -n $no_subcmd -a version -d 'Show version'
-    \\complete -c zmx -n $no_subcmd -a help -d 'Show help message'
+    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run k kill hi history w wait" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\
-    \\complete -c zmx -n "__fish_seen_subcommand_from attach run kill history" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
+    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from c completions" -a 'bash zsh fish' -d Shell
     \\
-    \\complete -c zmx -n "__fish_seen_subcommand_from completions" -a 'bash zsh fish' -d 'Shell'
-    \\
-    \\complete -c zmx -n "__fish_seen_subcommand_from list" -l short -d 'Short output'
+    \\complete -c zmx -n "__fish_seen_subcommand_from l list" -l short -d 'Short output'
+    \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l vt -d 'History format for escape sequences'
+    \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l html -d 'History format for escape sequences'
+
 ;


### PR DESCRIPTION
This pull request updates the Fish shell completion script for the `zmx` command. Improvements include:

* Explicit completion entries for each subcommand, including aliases (e.g., `a attach`, `r run`, etc.), and replace the original check with the builtin `__fish_is_nth_token` function.
* Adds context-aware completions for the second token, which avoids `zmx a session-name <TAB>` suggesting another session name.
* Adds option completions specific to certain subcommands, such as `--short` for `list`, and `--vt`/`--html` for `history`.
* Adds support for short and long flags for `version` and `help` commands.