### PR TITLE
fix: rewrite OSC 133;A with redraw=0 to prevent prompt loss on resize

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -699,8 +699,12 @@ const Daemon = struct {
             );
             if (util.serializeTerminalState(self.alloc, term)) |term_output| {
                 std.log.debug("serialize terminal state", .{});
+                // Rewrite OSC 133;A to include redraw=0 so the outer terminal
+                // does not clear prompt lines on resize (issue #111).
+                const restore_data = util.rewritePromptRedraw(self.alloc, term_output) orelse term_output;
                 defer self.alloc.free(term_output);
-                ipc.appendMessage(self.alloc, &client.write_buf, .Output, term_output) catch |err| {
+                defer if (restore_data.ptr != term_output.ptr) self.alloc.free(restore_data);
+                ipc.appendMessage(self.alloc, &client.write_buf, .Output, restore_data) catch |err| {
                     std.log.warn(
                         "failed to buffer terminal state for client err={s}",
                         .{@errorName(err)},
@@ -725,6 +729,13 @@ const Daemon = struct {
                 .ws_ypixel = 0,
             };
             _ = cross.c.ioctl(pty_fd, cross.c.TIOCSWINSZ, &ws);
+            // Disable prompt_redraw before resize. The daemon's internal terminal
+            // would otherwise clear prompt lines expecting the shell to redraw them,
+            // but the shell's redraw goes to the PTY (forwarded to clients), not to
+            // this daemon terminal. The clearing corrupts the daemon's snapshot state.
+            const saved_prompt_redraw = term.flags.shell_redraws_prompt;
+            term.flags.shell_redraws_prompt = .false;
+            defer term.flags.shell_redraws_prompt = saved_prompt_redraw;
             try term.resize(self.alloc, resize.cols, resize.rows);
 
             // Mark that we've had a client init, so subsequent clients get terminal state
@@ -756,6 +767,10 @@ const Daemon = struct {
             .ws_ypixel = 0,
         };
         _ = cross.c.ioctl(pty_fd, cross.c.TIOCSWINSZ, &ws);
+        // Disable prompt_redraw before resize (same rationale as handleInit).
+        const saved_prompt_redraw = term.flags.shell_redraws_prompt;
+        term.flags.shell_redraws_prompt = .false;
+        defer term.flags.shell_redraws_prompt = saved_prompt_redraw;
         try term.resize(self.alloc, resize.cols, resize.rows);
         std.log.debug("resize rows={d} cols={d}", .{ resize.rows, resize.cols });
     }
@@ -1817,9 +1832,13 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                         }
                     }
 
-                    // Broadcast data to all clients
+                    // Broadcast data to all clients.
+                    // Rewrite OSC 133;A to include redraw=0 so the outer terminal
+                    // does not clear prompt lines on resize (issue #111).
+                    const broadcast_data = util.rewritePromptRedraw(daemon.alloc, buf[0..n]) orelse buf[0..n];
+                    defer if (broadcast_data.ptr != buf[0..n].ptr) daemon.alloc.free(broadcast_data);
                     for (daemon.clients.items) |client| {
-                        ipc.appendMessage(daemon.alloc, &client.write_buf, .Output, buf[0..n]) catch |err| {
+                        ipc.appendMessage(daemon.alloc, &client.write_buf, .Output, broadcast_data) catch |err| {
                             std.log.warn(
                                 "failed to buffer output for client err={s}",
                                 .{@errorName(err)},

--- a/src/util.zig
+++ b/src/util.zig
@@ -184,6 +184,80 @@ fn matchSeq(data: []const u8, seq: []const u8) bool {
     return std.mem.eql(u8, data[0..seq.len], seq);
 }
 
+/// OSC 133;A (prompt start) marker.
+const OSC_133_A = "\x1b]133;A";
+
+/// Rewrite OSC 133;A sequences to include `redraw=0`, which tells the outer
+/// terminal not to clear prompt lines on resize. This is necessary because
+/// zmx sits between the shell and the outer terminal: from the outer terminal's
+/// perspective, the foreground process (zmx client) cannot redraw prompts.
+/// Without this, the outer terminal clears the prompt on resize expecting the
+/// shell to redraw it, but the shell's redraw goes through zmx's IPC path with
+/// cursor coordinates relative to the inner PTY, causing a cursor desync that
+/// makes the prompt invisible.
+/// See: https://github.com/neurosnap/zmx/issues/111
+pub fn rewritePromptRedraw(alloc: std.mem.Allocator, data: []const u8) ?[]const u8 {
+    // Quick scan: is there any OSC 133;A in this chunk?
+    if (std.mem.indexOf(u8, data, OSC_133_A) == null) return null;
+
+    var result = std.ArrayList(u8).initCapacity(alloc, data.len + 200) catch return null;
+    errdefer result.deinit(alloc);
+    result.appendSlice(alloc, data) catch return null;
+
+    // Work backwards so index shifts don't invalidate later positions.
+    var search_from: usize = result.items.len;
+    while (search_from > 0) {
+        const haystack = result.items[0..search_from];
+        const pos = std.mem.lastIndexOf(u8, haystack, OSC_133_A) orelse break;
+        search_from = pos;
+
+        const after = pos + OSC_133_A.len;
+        if (after >= result.items.len) continue;
+
+        // Find the string terminator (BEL \x07 or ST \x1b\\).
+        var term_pos: ?usize = null;
+        var j = after;
+        while (j < result.items.len) : (j += 1) {
+            if (result.items[j] == '\x07') {
+                term_pos = j;
+                break;
+            }
+            if (result.items[j] == '\x1b' and j + 1 < result.items.len and result.items[j + 1] == '\\') {
+                term_pos = j;
+                break;
+            }
+        }
+        const end = term_pos orelse continue;
+
+        // Check the parameter region between OSC_133_A and the terminator.
+        const params = result.items[after..end];
+
+        // If redraw=0 already present, skip.
+        if (std.mem.indexOf(u8, params, "redraw=0") != null) continue;
+
+        // If redraw= exists with a different value, replace it.
+        if (std.mem.indexOf(u8, params, "redraw=")) |rdw_offset| {
+            const abs_rdw = after + rdw_offset;
+            const value_start = abs_rdw + "redraw=".len;
+            var value_end = value_start;
+            while (value_end < end and result.items[value_end] != ';') : (value_end += 1) {}
+            result.replaceRange(alloc, value_start, value_end - value_start, "0") catch return null;
+            continue;
+        }
+
+        // No redraw= present. Insert ;redraw=0 before the terminator.
+        result.replaceRange(alloc, end, 0, ";redraw=0") catch return null;
+    }
+
+    // If nothing changed, free and return null.
+    if (std.mem.eql(u8, result.items, data)) {
+        result.deinit(alloc);
+        return null;
+    }
+
+    return result.toOwnedSlice(alloc) catch null;
+}
+
 pub fn findTaskExitMarker(output: []const u8) ?u8 {
     const marker = "ZMX_TASK_COMPLETED:";
 

--- a/src/util.zig
+++ b/src/util.zig
@@ -258,6 +258,71 @@ pub fn rewritePromptRedraw(alloc: std.mem.Allocator, data: []const u8) ?[]const 
     return result.toOwnedSlice(alloc) catch null;
 }
 
+test "rewritePromptRedraw: no OSC 133;A returns null" {
+    const result = rewritePromptRedraw(std.testing.allocator, "hello world");
+    try std.testing.expect(result == null);
+}
+
+test "rewritePromptRedraw: injects redraw=0 with BEL terminator" {
+    const input = "\x1b]133;A\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x07", result);
+}
+
+test "rewritePromptRedraw: injects redraw=0 with ST terminator" {
+    const input = "\x1b]133;A\x1b\\";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x1b\\", result);
+}
+
+test "rewritePromptRedraw: replaces existing redraw=1" {
+    const input = "\x1b]133;A;redraw=1\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x07", result);
+}
+
+test "rewritePromptRedraw: replaces existing redraw=last" {
+    const input = "\x1b]133;A;redraw=last\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;redraw=0\x07", result);
+}
+
+test "rewritePromptRedraw: preserves redraw=0 (no-op)" {
+    const result = rewritePromptRedraw(std.testing.allocator, "\x1b]133;A;redraw=0\x07");
+    try std.testing.expect(result == null);
+}
+
+test "rewritePromptRedraw: preserves other parameters" {
+    const input = "\x1b]133;A;aid=14;cl=line\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("\x1b]133;A;aid=14;cl=line;redraw=0\x07", result);
+}
+
+test "rewritePromptRedraw: handles multiple markers" {
+    const input = "before\x1b]133;A\x07middle\x1b]133;A;redraw=1\x07after";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("before\x1b]133;A;redraw=0\x07middle\x1b]133;A;redraw=0\x07after", result);
+}
+
+test "rewritePromptRedraw: does not touch OSC 133;B or 133;C" {
+    const input = "\x1b]133;B\x07\x1b]133;C\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input);
+    try std.testing.expect(result == null);
+}
+
+test "rewritePromptRedraw: embedded in larger output" {
+    const input = "some output\r\n\x1b]133;A\x07prompt$ \x1b]133;B\x07";
+    const result = rewritePromptRedraw(std.testing.allocator, input).?;
+    defer std.testing.allocator.free(result);
+    try std.testing.expectEqualStrings("some output\r\n\x1b]133;A;redraw=0\x07prompt$ \x1b]133;B\x07", result);
+}
+
 pub fn findTaskExitMarker(output: []const u8) ?u8 {
     const marker = "ZMX_TASK_COMPLETED:";
 


### PR DESCRIPTION
## Problem

Addresses #111. Possibly related to #99.

When zmx is used inside a terminal that supports shell integration (Ghostty, Kitty), the shell prompt disappears on resize. Pressing Enter or Ctrl-L brings it back.

This reproduces in **Ghostty's own app** — any terminal that implements the Kitty `shell_redraws_prompt` protocol is affected.

## Root Cause

The shell emits OSC 133;A (prompt start) sequences which flow raw through zmx to the outer terminal. This causes the outer terminal to set `shell_redraws_prompt = true`, meaning it will **clear prompt rows on resize** and expect the shell to redraw them.

But the outer terminal's PTY connects to the **zmx client process**, not the real shell. zmx client cannot redraw prompts. The real shell's SIGWINCH redraw goes through zmx's IPC relay chain, and its cursor movements are relative to the **inner** PTY state (which never cleared anything). The outer terminal's cursor is at the **cleared** position — cursor desync makes the prompt invisible.

```
WITHOUT FIX:

Shell                    zmx daemon           zmx client           Terminal
  │                          │                    │                    │
  ├─ \x1b]133;A\x07 ───────►├─ forward raw ─────►├─ stdout ──────────►│
  │  "prompt starts here"    │                    │                    │
  │                          │                    │    terminal sets    │
  │                          │                    │    shell_redraws_   │
  │                          │                    │    prompt = true    │
  │                          │                    │                    │
  │                     On resize:                │                    │
  │                          │                    │    terminal CLEARS  │
  │                          │                    │    prompt rows      │
  │                          │                    │    (expects shell   │
  │                          │                    │     to redraw)      │
  │                          │                    │                    │
  │  SIGWINCH ◄──────────────┤◄───────────────────┤◄───────────────────┤
  │  shell redraws           │                    │                    │
  │  (cursor relative to     │                    │                    │
  │   inner PTY state)  ────►├─ forward ─────────►├─ stdout ──────────►│
  │                          │                    │                    │
  │                          │                    │    CURSOR DESYNC    │
  │                          │                    │    prompt at wrong  │
  │                          │                    │    row → BLANK      │
```

## Fix

Rewrite OSC 133;A to include `redraw=0` before forwarding to clients. This is a [standard Kitty protocol extension](https://sw.kovidgoyal.net/kitty/shell-integration/#notes-for-shell-developers) that tells the outer terminal "this process cannot redraw prompts — do not clear them on resize."

From the outer terminal's perspective, this is semantically correct: the zmx client process genuinely cannot redraw prompts.

**Note:** This intentionally overrides any `redraw=` value the shell may have set (including `redraw=1` or `redraw=last`) because zmx's IPC relay chain means the outer terminal cannot rely on the shell's redraw capability regardless of what the shell claims. All other shell integration features (prompt navigation, semantic zones, command tracking) are preserved — only the redraw behavior changes.

```
WITH FIX:

Shell                    zmx daemon           zmx client           Terminal
  │                          │                    │                    │
  ├─ \x1b]133;A\x07 ───────►│                    │                    │
  │                     ★ REWRITE                 │                    │
  │                          │                    │                    │
  │                          ├─ \x1b]133;A;redraw=0\x07 ─────────────►│
  │                          │                    │                    │
  │                          │                    │    terminal sets    │
  │                          │                    │    shell_redraws_   │
  │                          │                    │    prompt = false   │
  │                          │                    │                    │
  │                     On resize:                │                    │
  │                          │                    │    terminal leaves  │
  │                          │                    │    prompt rows      │
  │                          │                    │    INTACT           │
  │                          │                    │                    │
  │                          │                    │    Prompt VISIBLE ✓ │
```

## Changes

**`src/util.zig`** — New `rewritePromptRedraw()` function:
- Scans byte buffers for `\x1b]133;A` sequences
- Injects `;redraw=0` before the string terminator (BEL or ST)
- Handles existing `redraw=` parameters (replaces value with `0`, doesn't duplicate)
- Returns null (no allocation) when no rewrite is needed
- Includes targeted tests (BEL/ST terminators, replace existing values, multiple markers, no-op when already `0`, preserves other parameters)

**`src/main.zig`** — Three changes:
1. **Daemon broadcast path**: Calls `rewritePromptRedraw()` on PTY output before forwarding to clients
2. **Session restore path** (`handleInit`): Calls `rewritePromptRedraw()` on serialized terminal state before sending to re-attaching clients
3. **Daemon resize** (`handleInit` + `handleResize`): Disables `shell_redraws_prompt` on the daemon's internal ghostty_vt terminal before `term.resize()` to prevent corrupting the daemon's snapshot state

## Known limitation

If an OSC 133;A sequence is split across two PTY read boundaries (4096-byte buffer), it will pass through without rewrite. This is extremely rare in practice — the sequence is <20 bytes and PTY writes are typically aligned to complete escape sequences.

## Testing

Tested manually with:

1. **Ghostty app** (standalone, not embedded)
   - Run `zmx attach test1`
   - Split pane (`Cmd+D`)
   - Run `zmx attach test2` in the new pane
   - Resize panes repeatedly — prompts remain visible
   - Without the fix, prompt disappears on resize and only returns on Enter/Ctrl-L

2. **Agent Studio** (Ghostty embedded via libghostty)
   - Create multiple terminal panes with zmx sessions
   - Insert new panes, resize existing panes
   - Prompts remain visible throughout

3. **Unit tests** — `zig build test` passes with 10 targeted tests for `rewritePromptRedraw`
 

### Video and images of tests
 The video shows 2 attached zmx terminals in ghostty 
<img width="3522" height="2406" alt="2026-03-30 0324 Ghostty agent-studio luna-295-stable-terminal-host ⎇ fixterminal-exit-close-and-redraw-2" src="https://github.com/user-attachments/assets/5e28855b-b623-45c6-8c1f-9c367d270738" />

https://github.com/user-attachments/assets/0095a498-829a-46dc-bb2a-dd1982079ed7
