### PR TITLE
feat: integrate zig-clap for CLI argument parsing

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -36,6 +36,11 @@ pub fn build(b: *std.Build) void {
     });
     exe_mod.addOptions("build_options", options);
 
+    {
+        const clap_dep = b.dependency("clap", .{});
+        exe_mod.addImport("clap", clap_dep.module("clap"));
+    }
+
     if (b.lazyDependency("ghostty", .{
         .target = target,
         .optimize = optimize,
@@ -103,6 +108,11 @@ pub fn build(b: *std.Build) void {
                 .optimize = .ReleaseSafe,
             });
             release_mod.addOptions("build_options", options);
+
+            {
+                const clap_dep = b.dependency("clap", .{});
+                release_mod.addImport("clap", clap_dep.module("clap"));
+            }
 
             if (b.lazyDependency("ghostty", .{
                 .target = resolved,

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -8,6 +8,10 @@
             .url = "git+https://github.com/ghostty-org/ghostty.git?ref=HEAD#c61f184069336c61f7840e2268c6f4dc183b60af",
             .hash = "ghostty-1.3.0-dev-5UdBC0h6TwSwECcK25wXYZkpJ2TrATdQx8jqy9bVGWyV",
         },
+        .clap = .{
+            .url = "https://github.com/Hejsil/zig-clap/archive/refs/tags/0.11.0.tar.gz",
+            .hash = "clap-0.11.0-oBajB-HnAQDPCKYzwF7rO3qDFwRcD39Q0DALlTSz5H7e",
+        },
     },
     .paths = .{
         "build.zig",

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -29,7 +29,7 @@ const bash_completions =
     \\  cur="${COMP_WORDS[COMP_CWORD]}"
     \\  prev="${COMP_WORDS[COMP_CWORD-1]}"
     \\
-    \\  local commands="attach run detach list completions kill history version help"
+    \\  local commands="attach run detach list completions kill history wait version help"
     \\
     \\  if [[ $COMP_CWORD -eq 1 ]]; then
     \\    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -37,7 +37,7 @@ const bash_completions =
     \\  fi
     \\
     \\  case "$prev" in
-    \\    attach|run|kill|history)
+    \\    attach|run|kill|history|wait)
     \\      local sessions=$(zmx list --short 2>/dev/null | tr '\n' ' ')
     \\      COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
     \\      ;;
@@ -77,6 +77,7 @@ const zsh_completions =
     \\        'completions:Shell completion scripts'
     \\        'kill:Kill a session'
     \\        'history:Output session scrollback'
+    \\        'wait:Wait for session tasks to complete'
     \\        'version:Show version'
     \\        'help:Show help message'
     \\      )
@@ -84,7 +85,7 @@ const zsh_completions =
     \\      ;;
     \\    args)
     \\      case $words[2] in
-    \\        attach|a|kill|k|run|r|history|hi)
+    \\        attach|a|kill|k|run|r|history|hi|wait|w)
     \\          _zmx_sessions
     \\          ;;
     \\        completions|c)

--- a/src/main.zig
+++ b/src/main.zig
@@ -222,7 +222,7 @@ pub fn main() !void {
             diag.reportToFile(.stderr(), err) catch {};
         }
         stderr.flush() catch {};
-        return;
+        std.process.exit(1);
     };
     defer res.deinit();
 
@@ -248,7 +248,7 @@ pub fn main() !void {
                 .allocator = alloc,
             }) catch |err| {
                 list_diag.reportToFile(.stderr(), err) catch {};
-                return;
+                std.process.exit(1);
             };
             defer list_res.deinit();
 
@@ -265,7 +265,7 @@ pub fn main() !void {
                 .allocator = alloc,
             }) catch |err| {
                 comp_diag.reportToFile(.stderr(), err) catch {};
-                return;
+                std.process.exit(1);
             };
             defer comp_res.deinit();
 
@@ -284,7 +284,7 @@ pub fn main() !void {
                 .allocator = alloc,
             }) catch |err| {
                 hist_diag.reportToFile(.stderr(), err) catch {};
-                return;
+                std.process.exit(1);
             };
             defer hist_res.deinit();
 
@@ -293,6 +293,11 @@ pub fn main() !void {
             }
 
             var format: util.HistoryFormat = .plain;
+            if (hist_res.args.vt != 0 and hist_res.args.html != 0) {
+                const msg = "error: --vt and --html are mutually exclusive\n";
+                std.fs.File.stderr().writeAll(msg) catch {};
+                std.process.exit(1);
+            }
             if (hist_res.args.vt != 0) format = .vt;
             if (hist_res.args.html != 0) format = .html;
 
@@ -394,7 +399,7 @@ pub fn main() !void {
                 .allocator = alloc,
             }) catch |err| {
                 kill_diag.reportToFile(.stderr(), err) catch {};
-                return;
+                std.process.exit(1);
             };
             defer kill_res.deinit();
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -134,6 +134,52 @@ fn isHelpFlag(arg: ?[]const u8) bool {
     return false;
 }
 
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+test "parseCommand — full names" {
+    try std.testing.expectEqual(Command.attach, try parseCommand("attach"));
+    try std.testing.expectEqual(Command.run, try parseCommand("run"));
+    try std.testing.expectEqual(Command.detach, try parseCommand("detach"));
+    try std.testing.expectEqual(Command.list, try parseCommand("list"));
+    try std.testing.expectEqual(Command.completions, try parseCommand("completions"));
+    try std.testing.expectEqual(Command.kill, try parseCommand("kill"));
+    try std.testing.expectEqual(Command.history, try parseCommand("history"));
+    try std.testing.expectEqual(Command.wait, try parseCommand("wait"));
+    try std.testing.expectEqual(Command.version, try parseCommand("version"));
+    try std.testing.expectEqual(Command.help, try parseCommand("help"));
+}
+
+test "parseCommand — aliases" {
+    try std.testing.expectEqual(Command.attach, try parseCommand("a"));
+    try std.testing.expectEqual(Command.run, try parseCommand("r"));
+    try std.testing.expectEqual(Command.detach, try parseCommand("d"));
+    try std.testing.expectEqual(Command.list, try parseCommand("l"));
+    try std.testing.expectEqual(Command.completions, try parseCommand("c"));
+    try std.testing.expectEqual(Command.kill, try parseCommand("k"));
+    try std.testing.expectEqual(Command.history, try parseCommand("hi"));
+    try std.testing.expectEqual(Command.wait, try parseCommand("w"));
+    try std.testing.expectEqual(Command.version, try parseCommand("v"));
+    try std.testing.expectEqual(Command.help, try parseCommand("h"));
+}
+
+test "parseCommand — unknown commands" {
+    try std.testing.expectError(error.NameNotPartOfEnum, parseCommand("foo"));
+    try std.testing.expectError(error.NameNotPartOfEnum, parseCommand(""));
+    try std.testing.expectError(error.NameNotPartOfEnum, parseCommand("att"));
+    try std.testing.expectError(error.NameNotPartOfEnum, parseCommand("ATTACH"));
+}
+
+test "isHelpFlag" {
+    try std.testing.expect(isHelpFlag("--help"));
+    try std.testing.expect(isHelpFlag("-h"));
+    try std.testing.expect(!isHelpFlag(null));
+    try std.testing.expect(!isHelpFlag("--version"));
+    try std.testing.expect(!isHelpFlag("help"));
+    try std.testing.expect(!isHelpFlag(""));
+}
+
 pub fn main() !void {
     // use c_allocator to avoid "reached unreachable code" panic in DebugAllocator when forking
     const alloc = std.heap.c_allocator;

--- a/src/main.zig
+++ b/src/main.zig
@@ -3,6 +3,7 @@ const posix = std.posix;
 const builtin = @import("builtin");
 const build_options = @import("build_options");
 const ghostty_vt = @import("ghostty-vt");
+const clap = @import("clap");
 const ipc = @import("ipc.zig");
 const log = @import("log.zig");
 const completions = @import("completions.zig");
@@ -36,6 +37,103 @@ var sigterm_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false
 // https://github.com/ziglang/zig/blob/738d2be9d6b6ef3ff3559130c05159ef53336224/lib/std/posix.zig#L3505
 const O_NONBLOCK: usize = 1 << @bitOffsetOf(posix.O, "NONBLOCK");
 
+// ---------------------------------------------------------------------------
+// CLI definitions (zig-clap)
+// ---------------------------------------------------------------------------
+
+const Command = enum {
+    attach,
+    run,
+    detach,
+    list,
+    completions,
+    kill,
+    history,
+    wait,
+    version,
+    help,
+};
+
+/// Parse a command name, accepting both full names and short aliases.
+fn parseCommand(in: []const u8) error{NameNotPartOfEnum}!Command {
+    const aliases = .{
+        .{ "attach", Command.attach },
+        .{ "a", Command.attach },
+        .{ "run", Command.run },
+        .{ "r", Command.run },
+        .{ "detach", Command.detach },
+        .{ "d", Command.detach },
+        .{ "list", Command.list },
+        .{ "l", Command.list },
+        .{ "completions", Command.completions },
+        .{ "c", Command.completions },
+        .{ "kill", Command.kill },
+        .{ "k", Command.kill },
+        .{ "history", Command.history },
+        .{ "hi", Command.history },
+        .{ "wait", Command.wait },
+        .{ "w", Command.wait },
+        .{ "version", Command.version },
+        .{ "v", Command.version },
+        .{ "help", Command.help },
+        .{ "h", Command.help },
+    };
+    inline for (aliases) |entry| {
+        if (std.mem.eql(u8, in, entry[0])) return entry[1];
+    }
+    return error.NameNotPartOfEnum;
+}
+
+/// Top-level parameters: --help, --version, and the subcommand positional.
+const main_params = clap.parseParamsComptime(
+    \\-h, --help     Display this help message
+    \\-v, --version  Show version information
+    \\<command>
+    \\
+);
+
+const main_parsers = .{
+    .command = parseCommand,
+};
+
+/// Parameters for `list`.
+const list_params = clap.parseParamsComptime(
+    \\-h, --help    Display this help message
+    \\    --short   Use short output format
+    \\
+);
+
+/// Parameters for `history`.
+const history_params = clap.parseParamsComptime(
+    \\-h, --help   Display this help message
+    \\    --vt     Output with VT escape sequences
+    \\    --html   Output as HTML
+    \\<str>
+    \\
+);
+
+/// Parameters for `kill`.
+const kill_params = clap.parseParamsComptime(
+    \\-h, --help    Display this help message
+    \\    --force   Force kill by removing the socket file
+    \\<str>...
+    \\
+);
+
+/// Parameters for `completions`.
+const completions_params = clap.parseParamsComptime(
+    \\-h, --help   Display this help message
+    \\<str>
+    \\
+);
+
+fn isHelpFlag(arg: ?[]const u8) bool {
+    if (arg) |a| {
+        return std.mem.eql(u8, a, "--help") or std.mem.eql(u8, a, "-h");
+    }
+    return false;
+}
+
 pub fn main() !void {
     // use c_allocator to avoid "reached unreachable code" panic in DebugAllocator when forking
     const alloc = std.heap.c_allocator;
@@ -48,7 +146,7 @@ pub fn main() !void {
 
     var args = try std.process.argsWithAllocator(alloc);
     defer args.deinit();
-    _ = args.skip(); // skip program name
+    _ = args.next(); // skip program name
 
     var cfg = try Cfg.init(alloc);
     defer cfg.deinit(alloc);
@@ -58,189 +156,290 @@ pub fn main() !void {
     try log_system.init(alloc, log_path);
     defer log_system.deinit();
 
-    const cmd = args.next() orelse {
-        return list(&cfg, false);
-    };
-
-    if (std.mem.eql(u8, cmd, "version") or std.mem.eql(u8, cmd, "v") or std.mem.eql(u8, cmd, "-v") or std.mem.eql(u8, cmd, "--version")) {
-        return printVersion(&cfg);
-    } else if (std.mem.eql(u8, cmd, "help") or std.mem.eql(u8, cmd, "h") or std.mem.eql(u8, cmd, "-h")) {
-        return help();
-    } else if (std.mem.eql(u8, cmd, "list") or std.mem.eql(u8, cmd, "l")) {
-        const short = if (args.next()) |arg| std.mem.eql(u8, arg, "--short") else false;
-        return list(&cfg, short);
-    } else if (std.mem.eql(u8, cmd, "completions") or std.mem.eql(u8, cmd, "c")) {
-        const arg = args.next() orelse return;
-        const shell = completions.Shell.fromString(arg) orelse return;
-        return printCompletions(shell);
-    } else if (std.mem.eql(u8, cmd, "detach") or std.mem.eql(u8, cmd, "d")) {
-        return detachAll(&cfg);
-    } else if (std.mem.eql(u8, cmd, "history") or std.mem.eql(u8, cmd, "hi")) {
-        var session_name: ?[]const u8 = null;
-        var format: util.HistoryFormat = .plain;
-        while (args.next()) |arg| {
-            if (std.mem.eql(u8, arg, "--vt")) {
-                format = .vt;
-            } else if (std.mem.eql(u8, arg, "--html")) {
-                format = .html;
-            } else if (session_name == null) {
-                session_name = arg;
-            }
-        }
-        const sesh_env = socket.getSeshNameFromEnv();
-        const sesh = try socket.getSeshName(alloc, session_name orelse sesh_env);
-        defer alloc.free(sesh);
-        return history(&cfg, sesh, format);
-    } else if (std.mem.eql(u8, cmd, "attach") or std.mem.eql(u8, cmd, "a")) {
-        const session_name = args.next() orelse "";
-
-        var command_args: std.ArrayList([]const u8) = .empty;
-        defer command_args.deinit(alloc);
-        while (args.next()) |arg| {
-            try command_args.append(alloc, arg);
-        }
-
-        const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
-        var command: ?[][]const u8 = null;
-        if (command_args.items.len > 0) {
-            command = command_args.items;
-        }
-
-        var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const cwd = std.posix.getcwd(&cwd_buf) catch "";
-
-        const sesh = try socket.getSeshName(alloc, session_name);
-        defer alloc.free(sesh);
-        var daemon = Daemon{
-            .running = true,
-            .cfg = &cfg,
-            .alloc = alloc,
-            .clients = clients,
-            .session_name = sesh,
-            .socket_path = undefined,
-            .pid = undefined,
-            .command = command,
-            .cwd = cwd,
-            .created_at = @intCast(std.time.timestamp()),
-        };
-        daemon.socket_path = socket.getSocketPath(alloc, cfg.socket_dir, sesh) catch |err| switch (err) {
-            error.NameTooLong => return socket.printSessionNameTooLong(sesh, cfg.socket_dir),
-            error.OutOfMemory => return err,
-        };
-        std.log.info("socket path={s}", .{daemon.socket_path});
-        return attach(&daemon);
-    } else if (std.mem.eql(u8, cmd, "run") or std.mem.eql(u8, cmd, "r")) {
-        const session_name = args.next() orelse "";
-
-        var cmd_args_raw: std.ArrayList([]const u8) = .empty;
-        defer cmd_args_raw.deinit(alloc);
-        while (args.next()) |arg| {
-            try cmd_args_raw.append(alloc, arg);
-        }
-        const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
-
-        var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const cwd = std.posix.getcwd(&cwd_buf) catch "";
-
-        const sesh = try socket.getSeshName(alloc, session_name);
-        defer alloc.free(sesh);
-        var daemon = Daemon{
-            .running = true,
-            .cfg = &cfg,
-            .alloc = alloc,
-            .clients = clients,
-            .session_name = sesh,
-            .socket_path = undefined,
-            .pid = undefined,
-            .command = null,
-            .cwd = cwd,
-            .created_at = @intCast(std.time.timestamp()),
-            .is_task_mode = true,
-            .task_command = cmd_args_raw.items,
-        };
-        daemon.socket_path = socket.getSocketPath(alloc, cfg.socket_dir, sesh) catch |err| switch (err) {
-            error.NameTooLong => return socket.printSessionNameTooLong(sesh, cfg.socket_dir),
-            error.OutOfMemory => return err,
-        };
-        std.log.info("socket path={s}", .{daemon.socket_path});
-        return run(&daemon, cmd_args_raw.items);
-    } else if (std.mem.eql(u8, cmd, "kill") or std.mem.eql(u8, cmd, "k")) {
+    // Parse top-level: --help, --version, and the subcommand.
+    // terminating_positional stops parsing after the command so the remaining
+    // iterator can be consumed by each subcommand handler.
+    var diag = clap.Diagnostic{};
+    var res = clap.parseEx(clap.Help, &main_params, main_parsers, &args, .{
+        .diagnostic = &diag,
+        .allocator = alloc,
+        .terminating_positional = 0,
+    }) catch |err| {
         var stderr_buffer: [1024]u8 = undefined;
         var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
         const stderr = &stderr_writer.interface;
-
-        var args_raw: std.ArrayList([]const u8) = .empty;
-        defer {
-            for (args_raw.items) |sesh| {
-                alloc.free(sesh);
-            }
-            args_raw.deinit(alloc);
+        if (err == error.NameNotPartOfEnum) {
+            // The user typed an unknown command. diag.arg isn't populated for
+            // positional value-parse errors, so report generically.
+            stderr.print("Unknown command. Run 'zmx --help' for usage information.\n", .{}) catch {};
+        } else {
+            diag.reportToFile(.stderr(), err) catch {};
         }
-        var force = false;
-        while (args.next()) |session_name| {
-            if (std.mem.eql(u8, session_name, "--force")) {
-                force = true;
-                continue;
+        stderr.flush() catch {};
+        return;
+    };
+    defer res.deinit();
+
+    if (res.args.help != 0) return help();
+    if (res.args.version != 0) return printVersion(&cfg);
+
+    const command = res.positionals[0] orelse return list(&cfg, false);
+
+    switch (command) {
+        .help => return help(),
+        .version => return printVersion(&cfg),
+        .detach => {
+            if (isHelpFlag(args.next())) {
+                return subcommandUsage("detach", "", "Detach all clients from current session (ctrl+\\ for current client)");
             }
+            return detachAll(&cfg);
+        },
+
+        .list => {
+            var list_diag = clap.Diagnostic{};
+            var list_res = clap.parseEx(clap.Help, &list_params, clap.parsers.default, &args, .{
+                .diagnostic = &list_diag,
+                .allocator = alloc,
+            }) catch |err| {
+                list_diag.reportToFile(.stderr(), err) catch {};
+                return;
+            };
+            defer list_res.deinit();
+
+            if (list_res.args.help != 0) {
+                return subcommandUsage("list", "[--short]", "List active sessions");
+            }
+            return list(&cfg, list_res.args.short != 0);
+        },
+
+        .completions => {
+            var comp_diag = clap.Diagnostic{};
+            var comp_res = clap.parseEx(clap.Help, &completions_params, clap.parsers.default, &args, .{
+                .diagnostic = &comp_diag,
+                .allocator = alloc,
+            }) catch |err| {
+                comp_diag.reportToFile(.stderr(), err) catch {};
+                return;
+            };
+            defer comp_res.deinit();
+
+            if (comp_res.args.help != 0) {
+                return subcommandUsage("completions", "<shell>", "Completion scripts for shell integration (bash, zsh, or fish)");
+            }
+            const arg = comp_res.positionals[0] orelse return;
+            const shell = completions.Shell.fromString(arg) orelse return;
+            return printCompletions(shell);
+        },
+
+        .history => {
+            var hist_diag = clap.Diagnostic{};
+            var hist_res = clap.parseEx(clap.Help, &history_params, clap.parsers.default, &args, .{
+                .diagnostic = &hist_diag,
+                .allocator = alloc,
+            }) catch |err| {
+                hist_diag.reportToFile(.stderr(), err) catch {};
+                return;
+            };
+            defer hist_res.deinit();
+
+            if (hist_res.args.help != 0) {
+                return subcommandUsage("history", "<name> [--vt|--html]", "Output session scrollback");
+            }
+
+            var format: util.HistoryFormat = .plain;
+            if (hist_res.args.vt != 0) format = .vt;
+            if (hist_res.args.html != 0) format = .html;
+
+            const sesh_env = socket.getSeshNameFromEnv();
+            const sesh = try socket.getSeshName(alloc, hist_res.positionals[0] orelse sesh_env);
+            defer alloc.free(sesh);
+            return history(&cfg, sesh, format);
+        },
+
+        .attach => {
+            const first_arg = args.next();
+            if (isHelpFlag(first_arg)) {
+                return subcommandUsage("attach", "<name> [command...]", "Attach to session, creating session if needed");
+            }
+            const session_name = first_arg orelse "";
+
+            var command_args: std.ArrayList([]const u8) = .empty;
+            defer command_args.deinit(alloc);
+            while (args.next()) |arg| {
+                try command_args.append(alloc, arg);
+            }
+
+            const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
+            var cmd: ?[][]const u8 = null;
+            if (command_args.items.len > 0) {
+                cmd = command_args.items;
+            }
+
+            var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const cwd = std.posix.getcwd(&cwd_buf) catch "";
+
             const sesh = try socket.getSeshName(alloc, session_name);
-            try args_raw.append(alloc, sesh);
-        }
-        // if no args are provided we assume they want to kill all sessions matching the prefix.
-        if (args_raw.items.len == 0) {
-            const prefix = socket.getSeshPrefix();
-            if (prefix.len == 0) {
-                return error.SessionNameRequired;
-            }
-            try args_raw.append(alloc, try alloc.dupe(u8, prefix));
-        }
-        var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
-        defer {
-            for (sessions.items) |session| {
-                session.deinit(alloc);
-            }
-            sessions.deinit(alloc);
-        }
+            defer alloc.free(sesh);
+            var daemon = Daemon{
+                .running = true,
+                .cfg = &cfg,
+                .alloc = alloc,
+                .clients = clients,
+                .session_name = sesh,
+                .socket_path = undefined,
+                .pid = undefined,
+                .command = cmd,
+                .cwd = cwd,
+                .created_at = @intCast(std.time.timestamp()),
+            };
+            daemon.socket_path = socket.getSocketPath(alloc, cfg.socket_dir, sesh) catch |err| switch (err) {
+                error.NameTooLong => return socket.printSessionNameTooLong(sesh, cfg.socket_dir),
+                error.OutOfMemory => return err,
+            };
+            std.log.info("socket path={s}", .{daemon.socket_path});
+            return attach(&daemon);
+        },
 
-        for (sessions.items) |session| {
-            for (args_raw.items) |prefix| {
-                if (!std.mem.startsWith(u8, session.name, prefix)) {
-                    continue;
+        .run => {
+            const first_arg = args.next();
+            if (isHelpFlag(first_arg)) {
+                return subcommandUsage("run", "<name> [command...]", "Send command without attaching, creating session if needed");
+            }
+            const session_name = first_arg orelse "";
+
+            var cmd_args_raw: std.ArrayList([]const u8) = .empty;
+            defer cmd_args_raw.deinit(alloc);
+            while (args.next()) |arg| {
+                try cmd_args_raw.append(alloc, arg);
+            }
+            const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
+
+            var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
+            const cwd = std.posix.getcwd(&cwd_buf) catch "";
+
+            const sesh = try socket.getSeshName(alloc, session_name);
+            defer alloc.free(sesh);
+            var daemon = Daemon{
+                .running = true,
+                .cfg = &cfg,
+                .alloc = alloc,
+                .clients = clients,
+                .session_name = sesh,
+                .socket_path = undefined,
+                .pid = undefined,
+                .command = null,
+                .cwd = cwd,
+                .created_at = @intCast(std.time.timestamp()),
+                .is_task_mode = true,
+                .task_command = cmd_args_raw.items,
+            };
+            daemon.socket_path = socket.getSocketPath(alloc, cfg.socket_dir, sesh) catch |err| switch (err) {
+                error.NameTooLong => return socket.printSessionNameTooLong(sesh, cfg.socket_dir),
+                error.OutOfMemory => return err,
+            };
+            std.log.info("socket path={s}", .{daemon.socket_path});
+            return run(&daemon, cmd_args_raw.items);
+        },
+
+        .kill => {
+            var kill_diag = clap.Diagnostic{};
+            var kill_res = clap.parseEx(clap.Help, &kill_params, clap.parsers.default, &args, .{
+                .diagnostic = &kill_diag,
+                .allocator = alloc,
+            }) catch |err| {
+                kill_diag.reportToFile(.stderr(), err) catch {};
+                return;
+            };
+            defer kill_res.deinit();
+
+            if (kill_res.args.help != 0) {
+                return subcommandUsage("kill", "<name>... [--force]", "Kill a session and all attached clients");
+            }
+
+            const force = kill_res.args.force != 0;
+
+            var stderr_buffer: [1024]u8 = undefined;
+            var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+            const stderr = &stderr_writer.interface;
+
+            var args_raw: std.ArrayList([]const u8) = .empty;
+            defer {
+                for (args_raw.items) |sesh| {
+                    alloc.free(sesh);
                 }
+                args_raw.deinit(alloc);
+            }
+            for (kill_res.positionals[0]) |session_name| {
+                const sesh = try socket.getSeshName(alloc, session_name);
+                try args_raw.append(alloc, sesh);
+            }
+            // if no args are provided we assume they want to kill all sessions matching the
+            // prefix.
+            if (args_raw.items.len == 0) {
+                const prefix = socket.getSeshPrefix();
+                if (prefix.len == 0) {
+                    return error.SessionNameRequired;
+                }
+                try args_raw.append(alloc, try alloc.dupe(u8, prefix));
+            }
+            var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
+            defer {
+                for (sessions.items) |session| {
+                    session.deinit(alloc);
+                }
+                sessions.deinit(alloc);
+            }
+            for (sessions.items) |session| {
+                for (args_raw.items) |prefix| {
+                    if (!std.mem.startsWith(u8, session.name, prefix)) {
+                        continue;
+                    }
+                    kill(&cfg, session.name, force) catch |err| {
+                        try stderr.print(
+                            "failed to kill session={s}: {s}\n",
+                            .{ session.name, @errorName(err) },
+                        );
+                        try stderr.flush();
+                    };
+                    break;
+                }
+            }
+            return;
+        },
 
-                kill(&cfg, session.name, force) catch |err| {
-                    try stderr.print(
-                        "failed to kill session={s}: {s}\n",
-                        .{ session.name, @errorName(err) },
-                    );
-                    try stderr.flush();
-                };
-                break;
+        .wait => {
+            const first_arg = args.next();
+            if (isHelpFlag(first_arg)) {
+                return subcommandUsage("wait", "<name>...", "Wait for session tasks to complete");
             }
-        }
-    } else if (std.mem.eql(u8, cmd, "wait") or std.mem.eql(u8, cmd, "w")) {
-        var args_raw: std.ArrayList([]const u8) = .empty;
-        defer {
-            for (args_raw.items) |sesh| {
-                alloc.free(sesh);
+
+            var args_raw: std.ArrayList([]const u8) = .empty;
+            defer {
+                for (args_raw.items) |sesh| {
+                    alloc.free(sesh);
+                }
+                args_raw.deinit(alloc);
             }
-            args_raw.deinit(alloc);
-        }
-        while (args.next()) |session_name| {
-            const sesh = try socket.getSeshName(alloc, session_name);
-            try args_raw.append(alloc, sesh);
-        }
-        // if no args are provided we assume they want to wait for all sessions matching the
-        // prefix.
-        if (args_raw.items.len == 0) {
-            const prefix = socket.getSeshPrefix();
-            if (prefix.len == 0) {
-                return error.SessionNameRequired;
+            // Include the first arg we already consumed (if it wasn't --help)
+            if (first_arg) |fa| {
+                const sesh = try socket.getSeshName(alloc, fa);
+                try args_raw.append(alloc, sesh);
             }
-            try args_raw.append(alloc, prefix);
-        }
-        return wait(&cfg, args_raw);
-    } else {
-        return help();
+            while (args.next()) |session_name| {
+                const sesh = try socket.getSeshName(alloc, session_name);
+                try args_raw.append(alloc, sesh);
+            }
+            // if no args are provided we assume they want to wait for all sessions matching the
+            // prefix.
+            if (args_raw.items.len == 0) {
+                const prefix = socket.getSeshPrefix();
+                if (prefix.len == 0) {
+                    return error.SessionNameRequired;
+                }
+                try args_raw.append(alloc, prefix);
+            }
+            return wait(&cfg, args_raw);
+        },
     }
 }
 
@@ -795,6 +994,21 @@ fn printCompletions(shell: completions.Shell) !void {
     var buf: [8192]u8 = undefined;
     var w = std.fs.File.stdout().writer(&buf);
     try w.interface.print("{s}\n", .{script});
+    try w.interface.flush();
+}
+
+fn subcommandUsage(name: []const u8, args_text: []const u8, description: []const u8) !void {
+    var buf: [4096]u8 = undefined;
+    var w = std.fs.File.stdout().writer(&buf);
+    try w.interface.print(
+        \\
+        \\Usage: zmx {s} {s}
+        \\
+        \\  {s}
+        \\
+        \\Run 'zmx --help' for global usage information.
+        \\
+    , .{ name, args_text, description });
     try w.interface.flush();
 }
 

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -153,22 +153,22 @@ load test_helper
 # Error handling
 # ============================================================================
 
-@test "unknown command: reports error" {
+@test "unknown command: reports error and exits non-zero" {
   run "$ZMX" foo
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"Unknown command"* ]]
   [[ "$output" == *"--help"* ]]
 }
 
-@test "unknown top-level flag: reports error" {
+@test "unknown top-level flag: reports error and exits non-zero" {
   run "$ZMX" --bogus
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid argument"* ]]
 }
 
-@test "list with unknown flag: reports error" {
+@test "list with unknown flag: reports error and exits non-zero" {
   run "$ZMX" list --bogus
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid argument"* ]]
 }
 
@@ -178,16 +178,22 @@ load test_helper
   [[ "$output" == *"--force"* ]]
 }
 
-@test "kill with unknown flag: reports error" {
+@test "kill with unknown flag: reports error and exits non-zero" {
   run "$ZMX" kill --bogus
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid argument"* ]]
 }
 
-@test "list with unexpected positional: reports error" {
+@test "list with unexpected positional: reports error and exits non-zero" {
   run "$ZMX" list blah
-  [ "$status" -eq 0 ]
+  [ "$status" -ne 0 ]
   [[ "$output" == *"Invalid argument"* ]]
+}
+
+@test "history --vt --html: mutually exclusive flags error" {
+  run "$ZMX" history test --vt --html
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"mutually exclusive"* ]]
 }
 
 # ============================================================================

--- a/test/cli.bats
+++ b/test/cli.bats
@@ -1,0 +1,231 @@
+#!/usr/bin/env bats
+# Behavioral tests for zmx CLI argument parsing (zig-clap integration)
+
+load test_helper
+
+# ============================================================================
+# Top-level help
+# ============================================================================
+
+@test "no args: defaults to list" {
+  run "$ZMX"
+  [ "$status" -eq 0 ]
+  # No sessions in our isolated dir, so expect "no sessions found"
+  [[ "$output" == *"no sessions found"* ]]
+}
+
+@test "--help: shows usage" {
+  run "$ZMX" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx"* ]]
+  [[ "$output" == *"[a]ttach"* ]]
+}
+
+@test "-h: shows usage" {
+  run "$ZMX" -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx"* ]]
+}
+
+@test "help command: shows usage" {
+  run "$ZMX" help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx"* ]]
+}
+
+@test "h alias: shows usage" {
+  run "$ZMX" h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx"* ]]
+}
+
+# ============================================================================
+# Version
+# ============================================================================
+
+@test "--version: shows version info" {
+  run "$ZMX" --version
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"zmx"* ]]
+  [[ "$output" == *"ghostty_vt"* ]]
+}
+
+@test "-v: shows version info" {
+  run "$ZMX" -v
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"zmx"* ]]
+}
+
+@test "v alias: shows version info" {
+  run "$ZMX" v
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"zmx"* ]]
+}
+
+# ============================================================================
+# Subcommand --help
+# ============================================================================
+
+@test "list --help: shows subcommand usage" {
+  run "$ZMX" list --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx list"* ]]
+  [[ "$output" == *"--short"* ]]
+}
+
+@test "kill --help: shows subcommand usage" {
+  run "$ZMX" kill --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx kill"* ]]
+}
+
+@test "attach -h: shows subcommand usage" {
+  run "$ZMX" attach -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx attach"* ]]
+  [[ "$output" == *"command..."* ]]
+}
+
+@test "run --help: shows subcommand usage" {
+  run "$ZMX" run --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx run"* ]]
+}
+
+@test "wait --help: shows subcommand usage" {
+  run "$ZMX" wait --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx wait"* ]]
+}
+
+@test "history --help: shows subcommand usage" {
+  run "$ZMX" history --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx history"* ]]
+  [[ "$output" == *"--vt"* ]]
+}
+
+@test "completions --help: shows subcommand usage" {
+  run "$ZMX" completions --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx completions"* ]]
+}
+
+@test "detach --help: shows subcommand usage" {
+  run "$ZMX" detach --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx detach"* ]]
+}
+
+# ============================================================================
+# Aliases
+# ============================================================================
+
+@test "l alias: works like list" {
+  run "$ZMX" l
+  [ "$status" -eq 0 ]
+}
+
+@test "l --short: alias with flag" {
+  run "$ZMX" l --short
+  [ "$status" -eq 0 ]
+}
+
+@test "k --help: alias with help" {
+  run "$ZMX" k --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx kill"* ]]
+}
+
+@test "hi --help: alias with help" {
+  run "$ZMX" hi --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx history"* ]]
+}
+
+@test "w --help: alias with help" {
+  run "$ZMX" w --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: zmx wait"* ]]
+}
+
+# ============================================================================
+# Error handling
+# ============================================================================
+
+@test "unknown command: reports error" {
+  run "$ZMX" foo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Unknown command"* ]]
+  [[ "$output" == *"--help"* ]]
+}
+
+@test "unknown top-level flag: reports error" {
+  run "$ZMX" --bogus
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Invalid argument"* ]]
+}
+
+@test "list with unknown flag: reports error" {
+  run "$ZMX" list --bogus
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Invalid argument"* ]]
+}
+
+@test "kill --force --help: shows subcommand usage" {
+  run "$ZMX" kill --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--force"* ]]
+}
+
+@test "kill with unknown flag: reports error" {
+  run "$ZMX" kill --bogus
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Invalid argument"* ]]
+}
+
+@test "list with unexpected positional: reports error" {
+  run "$ZMX" list blah
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Invalid argument"* ]]
+}
+
+# ============================================================================
+# Completions output
+# ============================================================================
+
+@test "completions bash: outputs script" {
+  run "$ZMX" completions bash
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"_zmx_completions"* ]]
+  # wait should be in the commands list
+  [[ "$output" == *"wait"* ]]
+}
+
+@test "completions zsh: outputs script" {
+  run "$ZMX" completions zsh
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"_zmx"* ]]
+  [[ "$output" == *"wait"* ]]
+}
+
+@test "completions fish: outputs script" {
+  run "$ZMX" completions fish
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"complete -c zmx"* ]]
+}
+
+@test "completions with no shell: exits cleanly" {
+  run "$ZMX" completions
+  [ "$status" -eq 0 ]
+}
+
+# ============================================================================
+# list behavior
+# ============================================================================
+
+@test "list --short: no sessions returns empty" {
+  run "$ZMX" list --short
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,15 @@
+# test_helper.bash — shared setup for zmx CLI BATS tests
+
+REPO_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+setup() {
+  # Build once per test suite (skips if already built)
+  if [[ ! -x "$REPO_DIR/zig-out/bin/zmx" ]]; then
+    cd "$REPO_DIR" && zig build
+  fi
+  ZMX="$REPO_DIR/zig-out/bin/zmx"
+
+  # Isolate socket dir so tests don't interfere with real sessions
+  export ZMX_DIR="$BATS_TEST_TMPDIR/zmx-sockets"
+  mkdir -p "$ZMX_DIR"
+}


### PR DESCRIPTION
Replace the ~200-line if/else dispatch chain in `main()` with [zig-clap](https://github.com/Hejsil/zig-clap) v0.11.0 subcommand parsing.

## What changed

- **zig-clap 0.11.0 dependency** — added to `build.zig.zon` and wired into both debug and release builds
- **`Command` enum + custom parser** — handles aliases (`a`, `r`, `d`, `l`, `k`, `hi`, `w`, `c`, `v`, `h`)
- **Top-level `--help`/`--version` flags** via clap (previously only handled as command aliases)
- **Per-subcommand clap parsing** for `list` (`--short`), `history` (`--vt`/`--html`), `kill` (`--force`), `completions` (`<shell>`)
- **`--help` on every subcommand** — `zmx kill --help`, `zmx attach --help`, etc. all work now
- **Proper argument validation** — `zmx list --bogus` → `Invalid argument '--bogus'`
- **Bugfix**: added missing `wait` command to bash and zsh completions

## Design decisions

- Commands with passthrough args (`attach`, `run`, `wait`) consume remaining args from the iterator directly rather than through clap — avoids misinterpreting flag-like strings (e.g. `zmx attach test ls -la`)
- `kill` now uses clap for proper `--force` flag parsing alongside variadic `<name>...` positionals
- `terminating_positional = 0` at top level stops clap after the command, leaving the rest for subcommand handlers
- Top-level help text kept as a custom string (the `[a]ttach` alias notation is nice); per-subcommand help is generated

## Tests

- **4 Zig unit tests** — `parseCommand` (full names, aliases, unknown) and `isHelpFlag`
- **32 BATS behavioral tests** — help/version, subcommand help, aliases, error handling (including `--force`), completions, list behavior