### PR TITLE
fix(io): reduce input latency across buffered socket and PTY writes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -10,24 +10,26 @@ const macos_targets: []const std.Target.Query = &.{
     .{ .cpu_arch = .aarch64, .os_tag = .macos },
 };
 
+const BuildRunStdIo = if (@hasDecl(std.process, "SpawnOptions"))
+    std.process.SpawnOptions.StdIo
+else
+    std.process.Child.StdIo;
+
+fn inheritBuildRunStdIo() BuildRunStdIo {
+    return if (@hasField(BuildRunStdIo, "inherit")) .inherit else .Inherit;
+}
+
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const version = b.option([]const u8, "version", "Version string for release") orelse
         @as([]const u8, @import("build.zig.zon").version);
 
-    const stdio_type = if (@hasDecl(std.process, "SpawnOptions"))
-        std.process.SpawnOptions.StdIo
-    else
-        std.process.Child.StdIo;
-    const inherit_stdio: stdio_type =
-        if (@hasField(stdio_type, "inherit")) .inherit else .Inherit;
-
     var code: u8 = 0;
     const git_sha = std.mem.trim(u8, b.runAllowFail(
         &.{ "git", "rev-parse", "--short", "HEAD" },
         &code,
-        inherit_stdio,
+        inheritBuildRunStdIo(),
     ) catch "unknown", "\n");
 
     const options = b.addOptions();

--- a/build.zig
+++ b/build.zig
@@ -16,11 +16,18 @@ pub fn build(b: *std.Build) void {
     const version = b.option([]const u8, "version", "Version string for release") orelse
         @as([]const u8, @import("build.zig.zon").version);
 
+    const stdio_type = if (@hasDecl(std.process, "SpawnOptions"))
+        std.process.SpawnOptions.StdIo
+    else
+        std.process.Child.StdIo;
+    const inherit_stdio: stdio_type =
+        if (@hasField(stdio_type, "inherit")) .inherit else .Inherit;
+
     var code: u8 = 0;
     const git_sha = std.mem.trim(u8, b.runAllowFail(
         &.{ "git", "rev-parse", "--short", "HEAD" },
         &code,
-        .Inherit,
+        inherit_stdio,
     ) catch "unknown", "\n");
 
     const options = b.addOptions();
@@ -81,6 +88,7 @@ pub fn build(b: *std.Build) void {
         const exe_unit_tests = b.addTest(.{
             .root_module = test_module,
         });
+        exe_unit_tests.linkLibC();
         const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
         test_step.dependOn(&run_exe_unit_tests.step);
     }

--- a/build.zig
+++ b/build.zig
@@ -10,15 +10,6 @@ const macos_targets: []const std.Target.Query = &.{
     .{ .cpu_arch = .aarch64, .os_tag = .macos },
 };
 
-const BuildRunStdIo = if (@hasDecl(std.process, "SpawnOptions"))
-    std.process.SpawnOptions.StdIo
-else
-    std.process.Child.StdIo;
-
-fn inheritBuildRunStdIo() BuildRunStdIo {
-    return if (@hasField(BuildRunStdIo, "inherit")) .inherit else .Inherit;
-}
-
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
@@ -29,7 +20,7 @@ pub fn build(b: *std.Build) void {
     const git_sha = std.mem.trim(u8, b.runAllowFail(
         &.{ "git", "rev-parse", "--short", "HEAD" },
         &code,
-        inheritBuildRunStdIo(),
+        .Inherit,
     ) catch "unknown", "\n");
 
     const options = b.addOptions();
@@ -90,7 +81,6 @@ pub fn build(b: *std.Build) void {
         const exe_unit_tests = b.addTest(.{
             .root_module = test_module,
         });
-        exe_unit_tests.linkLibC();
         const run_exe_unit_tests = b.addRunArtifact(exe_unit_tests);
         test_step.dependOn(&run_exe_unit_tests.step);
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -298,6 +298,10 @@ fn flushBufferedFd(
     return flushBufferedWithWriter(alloc, buf, fd, posix.write);
 }
 
+fn hasBufferedWritePending(result: FlushBufferedResult) bool {
+    return result == .advanced or result == .pending;
+}
+
 fn drainBufferedWithWriter(
     alloc: std.mem.Allocator,
     buf: *std.ArrayList(u8),
@@ -1936,7 +1940,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                     if (last) break :daemon_loop;
                     continue;
                 }
-                client.has_pending_output = flush_result == .pending;
+                client.has_pending_output = hasBufferedWritePending(flush_result);
             }
 
             if (revents & (posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL) != 0) {
@@ -1996,6 +2000,13 @@ test "flushBufferedFd leaves bytes queued when writer would block" {
         try flushBufferedFd(alloc, pipe_fds[1], &buf),
     );
     try std.testing.expectEqualStrings("clear", buf.items);
+}
+
+test "hasBufferedWritePending keeps partial and blocked writes armed" {
+    try std.testing.expect(hasBufferedWritePending(.advanced));
+    try std.testing.expect(hasBufferedWritePending(.pending));
+    try std.testing.expect(!hasBufferedWritePending(.drained));
+    try std.testing.expect(!hasBufferedWritePending(.closed));
 }
 
 test "flushBufferedWithWriter keeps unwritten tail after partial write" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -281,16 +281,17 @@ fn flushBufferedWithWriter(
 ) !FlushBufferedResult {
     if (buf.items.len == 0) return .drained;
 
-    const n = writeFn(writer_ctx, buf.items) catch |err| switch (err) {
+    const written = writeFn(writer_ctx, buf.items) catch |err| switch (err) {
         error.WouldBlock => return .pending,
         error.ConnectionResetByPeer, error.BrokenPipe => return .closed,
         else => return err,
     };
 
-    if (n == 0) return .pending;
+    if (written == 0) return .pending;
 
-    try buf.replaceRange(alloc, 0, n, &[_]u8{});
-    return if (buf.items.len == 0) .drained else .pending;
+    try buf.replaceRange(alloc, 0, written, &[_]u8{});
+    if (buf.items.len == 0) return .drained;
+    return .pending;
 }
 
 fn flushBufferedFd(

--- a/src/main.zig
+++ b/src/main.zig
@@ -1850,17 +1850,10 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                 daemon.pty_write_buf.replaceRange(daemon.alloc, 0, n, &[_]u8{}) catch unreachable;
             }
         }
-
-        var i: usize = daemon.clients.items.len;
-        // Only iterate over clients that were present when poll_fds was constructed
-        // poll_fds contains [server, pty, client0, client1, ...]
-        // So number of clients in poll_fds is poll_fds.items.len - 2
+        // Newly accepted clients are not in poll_fds yet, so only iterate over
+        // the clients that were present when this poll cycle started.
         const num_polled_clients = poll_fds.items.len - 2;
-        if (i > num_polled_clients) {
-            // If we have more clients than polled (i.e. we just accepted one), start from the
-            // polled ones
-            i = num_polled_clients;
-        }
+        var i: usize = @min(daemon.clients.items.len, num_polled_clients);
 
         clients_loop: while (i > 0) {
             i -= 1;

--- a/src/main.zig
+++ b/src/main.zig
@@ -290,8 +290,7 @@ fn flushBufferedWithWriter(
     if (written == 0) return .pending;
 
     try buf.replaceRange(alloc, 0, written, &[_]u8{});
-    if (buf.items.len == 0) return .drained;
-    return .pending;
+    return if (buf.items.len == 0) .drained else .pending;
 }
 
 fn flushBufferedFd(
@@ -1677,9 +1676,9 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
         // new bytes earlier in the same iteration, try a non-blocking flush now
         // so single-key inputs like Ctrl-L do not wait for the next poll cycle.
         if (sock_write_buf.items.len > 0) {
-            switch (try flushBufferedFd(alloc, client_sock_fd, &sock_write_buf)) {
-                .drained, .pending => {},
-                .closed => return ClientResult{ .kind = .detach, .session_name = null },
+            const flush_result = try flushBufferedFd(alloc, client_sock_fd, &sock_write_buf);
+            if (flush_result == .closed) {
+                return ClientResult{ .kind = .detach, .session_name = null };
             }
         }
 
@@ -1921,15 +1920,13 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
             }
 
             if (client.write_buf.items.len > 0) {
-                switch (try flushBufferedFd(daemon.alloc, client.socket_fd, &client.write_buf)) {
-                    .drained => client.has_pending_output = false,
-                    .pending => client.has_pending_output = true,
-                    .closed => {
-                        const last = daemon.closeClient(client, i, false);
-                        if (last) break :daemon_loop;
-                        continue;
-                    },
+                const flush_result = try flushBufferedFd(daemon.alloc, client.socket_fd, &client.write_buf);
+                if (flush_result == .closed) {
+                    const last = daemon.closeClient(client, i, false);
+                    if (last) break :daemon_loop;
+                    continue;
                 }
+                client.has_pending_output = flush_result == .pending;
             }
 
             if (revents & (posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL) != 0) {
@@ -1967,7 +1964,7 @@ test "flushBufferedFd leaves bytes queued when writer would block" {
     defer posix.close(pipe_fds[0]);
     defer posix.close(pipe_fds[1]);
 
-    var fill_buf = [_]u8{0} ** 4096;
+    const fill_buf = [_]u8{0} ** 4096;
     while (true) {
         _ = posix.write(pipe_fds[1], &fill_buf) catch |err| switch (err) {
             error.WouldBlock => break,

--- a/src/main.zig
+++ b/src/main.zig
@@ -263,6 +263,44 @@ const Client = struct {
     }
 };
 
+const FlushBufferedResult = enum {
+    drained,
+    pending,
+    closed,
+};
+
+fn writeToFd(fd: i32, data: []const u8) !usize {
+    return posix.write(fd, data);
+}
+
+fn flushBufferedWithWriter(
+    alloc: std.mem.Allocator,
+    buf: *std.ArrayList(u8),
+    writer_ctx: anytype,
+    comptime writeFn: fn (@TypeOf(writer_ctx), []const u8) anyerror!usize,
+) !FlushBufferedResult {
+    if (buf.items.len == 0) return .drained;
+
+    const n = writeFn(writer_ctx, buf.items) catch |err| switch (err) {
+        error.WouldBlock => return .pending,
+        error.ConnectionResetByPeer, error.BrokenPipe => return .closed,
+        else => return err,
+    };
+
+    if (n == 0) return .pending;
+
+    try buf.replaceRange(alloc, 0, n, &[_]u8{});
+    return if (buf.items.len == 0) .drained else .pending;
+}
+
+fn flushBufferedFd(
+    alloc: std.mem.Allocator,
+    fd: i32,
+    buf: *std.ArrayList(u8),
+) !FlushBufferedResult {
+    return flushBufferedWithWriter(alloc, buf, fd, writeToFd);
+}
+
 /// Cfg is zmx's configuration container.
 ///
 /// The purpose of this container is to hold anything that can be modified by the user.
@@ -1634,19 +1672,13 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
             }
         }
 
-        // Handle socket write (flush buffered messages to daemon)
-        if (poll_fds.items[1].revents & posix.POLL.OUT != 0) {
-            if (sock_write_buf.items.len > 0) {
-                const n = posix.write(client_sock_fd, sock_write_buf.items) catch |err| blk: {
-                    if (err == error.WouldBlock) break :blk 0;
-                    if (err == error.ConnectionResetByPeer or err == error.BrokenPipe) {
-                        return ClientResult{ .kind = .detach, .session_name = null };
-                    }
-                    return err;
-                };
-                if (n > 0) {
-                    try sock_write_buf.replaceRange(alloc, 0, n, &[_]u8{});
-                }
+        // POLLOUT is only a wakeup for continued draining. If this loop appended
+        // new bytes earlier in the same iteration, try a non-blocking flush now
+        // so single-key inputs like Ctrl-L do not wait for the next poll cycle.
+        if (sock_write_buf.items.len > 0) {
+            switch (try flushBufferedFd(alloc, client_sock_fd, &sock_write_buf)) {
+                .drained, .pending => {},
+                .closed => return ClientResult{ .kind = .detach, .session_name = null },
             }
         }
 
@@ -1887,22 +1919,15 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                 }
             }
 
-            if (revents & posix.POLL.OUT != 0) {
-                // Flush pending output buffers
-                const n = posix.write(client.socket_fd, client.write_buf.items) catch |err| blk: {
-                    if (err == error.WouldBlock) break :blk 0;
-                    // Error on write, close client
-                    const last = daemon.closeClient(client, i, false);
-                    if (last) break :daemon_loop;
-                    continue;
-                };
-
-                if (n > 0) {
-                    client.write_buf.replaceRange(daemon.alloc, 0, n, &[_]u8{}) catch unreachable;
-                }
-
-                if (client.write_buf.items.len == 0) {
-                    client.has_pending_output = false;
+            if (client.write_buf.items.len > 0) {
+                switch (try flushBufferedFd(daemon.alloc, client.socket_fd, &client.write_buf)) {
+                    .drained => client.has_pending_output = false,
+                    .pending => client.has_pending_output = true,
+                    .closed => {
+                        const last = daemon.closeClient(client, i, false);
+                        if (last) break :daemon_loop;
+                        continue;
+                    },
                 }
             }
 
@@ -1912,6 +1937,75 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
             }
         }
     }
+}
+
+test "flushBufferedFd drains writable file descriptor immediately" {
+    const alloc = std.testing.allocator;
+    const pipe_fds = try posix.pipe();
+    defer posix.close(pipe_fds[0]);
+    defer posix.close(pipe_fds[1]);
+
+    var buf = try std.ArrayList(u8).initCapacity(alloc, 16);
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "ctrl-l");
+
+    try std.testing.expectEqual(
+        FlushBufferedResult.drained,
+        try flushBufferedFd(alloc, pipe_fds[1], &buf),
+    );
+    try std.testing.expectEqual(@as(usize, 0), buf.items.len);
+
+    var read_buf: [16]u8 = undefined;
+    const n = try posix.read(pipe_fds[0], &read_buf);
+    try std.testing.expectEqualStrings("ctrl-l", read_buf[0..n]);
+}
+
+test "flushBufferedFd leaves bytes queued when writer would block" {
+    const alloc = std.testing.allocator;
+    const pipe_fds = try posix.pipe2(.{ .NONBLOCK = true, .CLOEXEC = true });
+    defer posix.close(pipe_fds[0]);
+    defer posix.close(pipe_fds[1]);
+
+    var fill_buf = [_]u8{0} ** 4096;
+    while (true) {
+        _ = posix.write(pipe_fds[1], &fill_buf) catch |err| switch (err) {
+            error.WouldBlock => break,
+            else => return err,
+        };
+    }
+
+    var buf = try std.ArrayList(u8).initCapacity(alloc, 16);
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "clear");
+
+    try std.testing.expectEqual(
+        FlushBufferedResult.pending,
+        try flushBufferedFd(alloc, pipe_fds[1], &buf),
+    );
+    try std.testing.expectEqualStrings("clear", buf.items);
+}
+
+test "flushBufferedWithWriter keeps unwritten tail after partial write" {
+    const alloc = std.testing.allocator;
+
+    const PartialWriter = struct {
+        limit: usize,
+
+        fn write(self: *@This(), data: []const u8) !usize {
+            return @min(self.limit, data.len);
+        }
+    };
+
+    var writer = PartialWriter{ .limit = 3 };
+    var buf = try std.ArrayList(u8).initCapacity(alloc, 16);
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "clear-screen");
+
+    try std.testing.expectEqual(
+        FlushBufferedResult.pending,
+        try flushBufferedWithWriter(alloc, &buf, &writer, PartialWriter.write),
+    );
+    try std.testing.expectEqualStrings("ar-screen", buf.items);
 }
 
 fn handleSigwinch(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -269,10 +269,6 @@ const FlushBufferedResult = enum {
     closed,
 };
 
-fn writeToFd(fd: i32, data: []const u8) !usize {
-    return posix.write(fd, data);
-}
-
 fn flushBufferedWithWriter(
     alloc: std.mem.Allocator,
     buf: *std.ArrayList(u8),
@@ -298,7 +294,7 @@ fn flushBufferedFd(
     fd: i32,
     buf: *std.ArrayList(u8),
 ) !FlushBufferedResult {
-    return flushBufferedWithWriter(alloc, buf, fd, writeToFd);
+    return flushBufferedWithWriter(alloc, buf, fd, posix.write);
 }
 
 /// Cfg is zmx's configuration container.

--- a/src/main.zig
+++ b/src/main.zig
@@ -265,6 +265,7 @@ const Client = struct {
 
 const FlushBufferedResult = enum {
     drained,
+    advanced,
     pending,
     closed,
 };
@@ -286,7 +287,7 @@ fn flushBufferedWithWriter(
     if (written == 0) return .pending;
 
     try buf.replaceRange(alloc, 0, written, &[_]u8{});
-    return if (buf.items.len == 0) .drained else .pending;
+    return if (buf.items.len == 0) .drained else .advanced;
 }
 
 fn flushBufferedFd(
@@ -297,14 +298,26 @@ fn flushBufferedFd(
     return flushBufferedWithWriter(alloc, buf, fd, posix.write);
 }
 
-fn flushBufferedPty(
+fn drainBufferedWithWriter(
+    alloc: std.mem.Allocator,
+    buf: *std.ArrayList(u8),
+    writer_ctx: anytype,
+    comptime writeFn: fn (@TypeOf(writer_ctx), []const u8) anyerror!usize,
+) !FlushBufferedResult {
+    while (true) {
+        const flush_result = try flushBufferedWithWriter(alloc, buf, writer_ctx, writeFn);
+        if (flush_result != .advanced) return flush_result;
+    }
+}
+
+fn drainBufferedPty(
     alloc: std.mem.Allocator,
     fd: i32,
     buf: *std.ArrayList(u8),
 ) void {
     if (buf.items.len == 0) return;
 
-    const flush_result = flushBufferedFd(alloc, fd, buf) catch |err| {
+    const flush_result = drainBufferedWithWriter(alloc, buf, fd, posix.write) catch |err| {
         std.log.warn("pty write failed: {s}", .{@errorName(err)});
         buf.clearRetainingCapacity();
         return;
@@ -1856,10 +1869,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
         }
 
         if (poll_fds.items[1].revents & posix.POLL.OUT != 0) {
-            while (daemon.pty_write_buf.items.len > 0) {
-                flushBufferedPty(daemon.alloc, pty_fd, &daemon.pty_write_buf);
-                if (daemon.pty_write_buf.items.len > 0) break;
-            }
+            drainBufferedPty(daemon.alloc, pty_fd, &daemon.pty_write_buf);
         }
         // Newly accepted clients are not in poll_fds yet, so only iterate over
         // the clients that were present when this poll cycle started.
@@ -1938,7 +1948,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
         // If client input or terminal-query handling queued PTY bytes during this
         // poll cycle, try a non-blocking flush now instead of waiting for the
         // next POLLOUT wakeup.
-        flushBufferedPty(daemon.alloc, pty_fd, &daemon.pty_write_buf);
+        drainBufferedPty(daemon.alloc, pty_fd, &daemon.pty_write_buf);
     }
 }
 
@@ -2005,13 +2015,40 @@ test "flushBufferedWithWriter keeps unwritten tail after partial write" {
     try buf.appendSlice(alloc, "clear-screen");
 
     try std.testing.expectEqual(
-        FlushBufferedResult.pending,
+        FlushBufferedResult.advanced,
         try flushBufferedWithWriter(alloc, &buf, &writer, PartialWriter.write),
     );
     try std.testing.expectEqualStrings("ar-screen", buf.items);
 }
 
-test "flushBufferedPty drains writable file descriptor immediately" {
+test "drainBufferedWithWriter continues after partial writes" {
+    const alloc = std.testing.allocator;
+
+    const MultiWriter = struct {
+        steps: []const usize,
+        calls: usize = 0,
+
+        fn write(self: *@This(), data: []const u8) !usize {
+            const step = if (self.calls < self.steps.len) self.steps[self.calls] else data.len;
+            self.calls += 1;
+            return @min(step, data.len);
+        }
+    };
+
+    var writer = MultiWriter{ .steps = &.{ 3, 4 } };
+    var buf = try std.ArrayList(u8).initCapacity(alloc, 16);
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "clear-screen");
+
+    try std.testing.expectEqual(
+        FlushBufferedResult.drained,
+        try drainBufferedWithWriter(alloc, &buf, &writer, MultiWriter.write),
+    );
+    try std.testing.expectEqual(@as(usize, 0), buf.items.len);
+    try std.testing.expectEqual(@as(usize, 3), writer.calls);
+}
+
+test "drainBufferedPty drains writable file descriptor immediately" {
     const alloc = std.testing.allocator;
     const pipe_fds = try posix.pipe();
     defer posix.close(pipe_fds[0]);
@@ -2021,7 +2058,7 @@ test "flushBufferedPty drains writable file descriptor immediately" {
     defer buf.deinit(alloc);
     try buf.appendSlice(alloc, "ctrl-l");
 
-    flushBufferedPty(alloc, pipe_fds[1], &buf);
+    drainBufferedPty(alloc, pipe_fds[1], &buf);
     try std.testing.expectEqual(@as(usize, 0), buf.items.len);
 
     var read_buf: [16]u8 = undefined;
@@ -2029,14 +2066,14 @@ test "flushBufferedPty drains writable file descriptor immediately" {
     try std.testing.expectEqualStrings("ctrl-l", read_buf[0..n]);
 }
 
-test "flushBufferedPty clears buffered bytes on write error" {
+test "drainBufferedPty clears buffered bytes on write error" {
     const alloc = std.testing.allocator;
 
     var buf = try std.ArrayList(u8).initCapacity(alloc, 16);
     defer buf.deinit(alloc);
     try buf.appendSlice(alloc, "clear");
 
-    flushBufferedPty(alloc, -1, &buf);
+    drainBufferedPty(alloc, -1, &buf);
     try std.testing.expectEqual(@as(usize, 0), buf.items.len);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -297,6 +297,24 @@ fn flushBufferedFd(
     return flushBufferedWithWriter(alloc, buf, fd, posix.write);
 }
 
+fn flushBufferedPty(
+    alloc: std.mem.Allocator,
+    fd: i32,
+    buf: *std.ArrayList(u8),
+) void {
+    if (buf.items.len == 0) return;
+
+    const flush_result = flushBufferedFd(alloc, fd, buf) catch |err| {
+        std.log.warn("pty write failed: {s}", .{@errorName(err)});
+        buf.clearRetainingCapacity();
+        return;
+    };
+
+    if (flush_result == .closed) {
+        buf.clearRetainingCapacity();
+    }
+}
+
 /// Cfg is zmx's configuration container.
 ///
 /// The purpose of this container is to hold anything that can be modified by the user.
@@ -1839,15 +1857,8 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
 
         if (poll_fds.items[1].revents & posix.POLL.OUT != 0) {
             while (daemon.pty_write_buf.items.len > 0) {
-                const n = posix.write(pty_fd, daemon.pty_write_buf.items) catch |err| {
-                    if (err != error.WouldBlock) {
-                        std.log.warn("pty write failed: {s}", .{@errorName(err)});
-                        daemon.pty_write_buf.clearRetainingCapacity();
-                    }
-                    break;
-                };
-                if (n == 0) break;
-                daemon.pty_write_buf.replaceRange(daemon.alloc, 0, n, &[_]u8{}) catch unreachable;
+                flushBufferedPty(daemon.alloc, pty_fd, &daemon.pty_write_buf);
+                if (daemon.pty_write_buf.items.len > 0) break;
             }
         }
         // Newly accepted clients are not in poll_fds yet, so only iterate over
@@ -1923,6 +1934,11 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                 if (last) break :daemon_loop;
             }
         }
+
+        // If client input or terminal-query handling queued PTY bytes during this
+        // poll cycle, try a non-blocking flush now instead of waiting for the
+        // next POLLOUT wakeup.
+        flushBufferedPty(daemon.alloc, pty_fd, &daemon.pty_write_buf);
     }
 }
 
@@ -1993,6 +2009,35 @@ test "flushBufferedWithWriter keeps unwritten tail after partial write" {
         try flushBufferedWithWriter(alloc, &buf, &writer, PartialWriter.write),
     );
     try std.testing.expectEqualStrings("ar-screen", buf.items);
+}
+
+test "flushBufferedPty drains writable file descriptor immediately" {
+    const alloc = std.testing.allocator;
+    const pipe_fds = try posix.pipe();
+    defer posix.close(pipe_fds[0]);
+    defer posix.close(pipe_fds[1]);
+
+    var buf = try std.ArrayList(u8).initCapacity(alloc, 16);
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "ctrl-l");
+
+    flushBufferedPty(alloc, pipe_fds[1], &buf);
+    try std.testing.expectEqual(@as(usize, 0), buf.items.len);
+
+    var read_buf: [16]u8 = undefined;
+    const n = try posix.read(pipe_fds[0], &read_buf);
+    try std.testing.expectEqualStrings("ctrl-l", read_buf[0..n]);
+}
+
+test "flushBufferedPty clears buffered bytes on write error" {
+    const alloc = std.testing.allocator;
+
+    var buf = try std.ArrayList(u8).initCapacity(alloc, 16);
+    defer buf.deinit(alloc);
+    try buf.appendSlice(alloc, "clear");
+
+    flushBufferedPty(alloc, -1, &buf);
+    try std.testing.expectEqual(@as(usize, 0), buf.items.len);
 }
 
 fn handleSigwinch(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {


### PR DESCRIPTION
## Compared with main

### Summary
Reduce input latency across buffered socket and PTY writes.

### Problem
Single-key inputs such as `Ctrl-L` could sometimes feel delayed because client input could sit in buffered client-to-daemon or daemon-to-PTY writes until a later `POLLOUT` wakeup.

### What changed
- Added shared buffered-flush helpers that report whether writes were drained, made partial progress, were still blocked, or were closed.
- Flush client-to-daemon buffered writes immediately within the same loop iteration when possible.
- Keep daemon-to-client `POLLOUT` interest armed after partial writes so remaining buffered output continues draining in later cycles.
- Flush daemon-to-PTY buffered writes again at the end of the current poll cycle and continue draining partial PTY writes within the same wakeup when possible.
- Added unit tests covering immediate drain, would-block, partial-write behavior, repeated partial drains, pending-state handling, and PTY write error handling.

### Testing
- `zig build test`
