### PR TITLE
fix(daemon): self-pipe signal wakeup + version-tolerant IPC liveness

### DIFF
--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -24,6 +24,12 @@ pub const Tag = enum(u8) {
     _,
 };
 
+comptime {
+    if (@typeInfo(Tag).@"enum".is_exhaustive) @compileError(
+        "ipc.Tag must stay non-exhaustive — old daemons rely on `_` to ignore unknown tags",
+    );
+}
+
 pub const Header = packed struct {
     tag: Tag,
     len: u32,
@@ -184,8 +190,8 @@ const ConnectError = error{
     Unexpected,
 };
 
-/// Unlike `probeSession`, does not round-trip `Info` — kill/detach/history/run
-/// stay usable against version-skewed daemons.
+/// Connect-only liveness check. Callers that don't read `Info` should use
+/// this (not `probeSession`) so they survive `Info` shape changes.
 pub fn connectSession(socket_path: []const u8) ConnectError!i32 {
     return socket.sessionConnect(socket_path) catch |err| switch (err) {
         error.ConnectionRefused => return error.ConnectionRefused,
@@ -239,12 +245,29 @@ pub fn probeSession(
     return error.Unexpected;
 }
 
+// ╔════════════════════════════════════════════════════════════════════╗
+// ║ WIRE PROTOCOL FREEZE — read before "fixing" any test below.        ║
+// ║                                                                    ║
+// ║ Changing these constants does not fix the test; it breaks every    ║
+// ║ running daemon for every user until they `pkill -f zmx`.           ║
+// ║                                                                    ║
+// ║ Need a new field?  → add a new `Tag` value (next free integer).    ║
+// ║ Need to remove one? → don't. Reserve the integer, stop sending it. ║
+// ╚════════════════════════════════════════════════════════════════════╝
 test "Info wire size is frozen" {
-    // Bumping this means version-skewed `zmx list` breaks. See doc comment
-    // on `Info` — add a new `Tag` instead of growing this struct.
     try std.testing.expectEqual(@as(usize, 552), @sizeOf(Info));
     // packed struct{u8,u32} backs to u40 → @sizeOf rounds to 8, not 5.
     try std.testing.expectEqual(@as(usize, 8), @sizeOf(Header));
+}
+
+test "Tag wire values are frozen" {
+    inline for (.{
+        .{ Tag.Input, 0 },  .{ Tag.Output, 1 },        .{ Tag.Resize, 2 },
+        .{ Tag.Detach, 3 }, .{ Tag.DetachAll, 4 },     .{ Tag.Kill, 5 },
+        .{ Tag.Info, 6 },   .{ Tag.Init, 7 },          .{ Tag.History, 8 },
+        .{ Tag.Run, 9 },    .{ Tag.Ack, 10 },          .{ Tag.Switch, 11 },
+        .{ Tag.Write, 12 }, .{ Tag.TaskComplete, 13 },
+    }) |p| try std.testing.expectEqual(@as(u8, p[1]), @intFromEnum(p[0]));
 }
 
 test "zeroed Info has no stack garbage in wire bytes" {

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -19,7 +19,7 @@ pub const Tag = enum(u8) {
     Write = 12,
     TaskComplete = 13,
     // Non-exhaustive: this enum comes off the wire via bytesToValue and
-    // @enumFromInt, so out-of-range values (11-255) are representable
+    // @enumFromInt, so out-of-range values (14-255) are representable
     // rather than UB. Switches must handle `_` (unknown tag).
     _,
 };
@@ -45,8 +45,11 @@ pub fn getTerminalSize(fd: i32) Resize {
 pub const MAX_CMD_LEN = 256;
 pub const MAX_CWD_LEN = 256;
 
+/// Frozen wire shape. Do NOT add fields — new stats go in new `Tag` values
+/// so old daemons (whose `_` arm ignores unknown tags) stay reachable.
+/// Changing `@sizeOf(Info)` breaks `zmx list` against running daemons.
 pub const Info = extern struct {
-    clients_len: usize,
+    clients_len: u64,
     pid: i32,
     cmd_len: u16,
     cwd_len: u16,
@@ -176,10 +179,25 @@ pub const SocketBuffer = struct {
     }
 };
 
+const ConnectError = error{
+    ConnectionRefused,
+    Unexpected,
+};
+
+/// Unlike `probeSession`, does not round-trip `Info` — kill/detach/history/run
+/// stay usable against version-skewed daemons.
+pub fn connectSession(socket_path: []const u8) ConnectError!i32 {
+    return socket.sessionConnect(socket_path) catch |err| switch (err) {
+        error.ConnectionRefused => return error.ConnectionRefused,
+        else => return error.Unexpected,
+    };
+}
+
 const SessionProbeError = error{
     Timeout,
     ConnectionRefused,
     Unexpected,
+    InfoSizeMismatch,
 };
 
 const SessionProbeResult = struct {
@@ -192,10 +210,7 @@ pub fn probeSession(
     socket_path: []const u8,
 ) SessionProbeError!SessionProbeResult {
     const timeout_ms = 1000;
-    const fd = socket.sessionConnect(socket_path) catch |err| switch (err) {
-        error.ConnectionRefused => return error.ConnectionRefused,
-        else => return error.Unexpected,
-    };
+    const fd = try connectSession(socket_path);
     errdefer posix.close(fd);
 
     send(fd, .Info, "") catch return error.Unexpected;
@@ -214,13 +229,31 @@ pub fn probeSession(
 
     while (sb.next()) |msg| {
         if (msg.header.tag == .Info) {
-            if (msg.payload.len == @sizeOf(Info)) {
-                return .{
-                    .fd = fd,
-                    .info = std.mem.bytesToValue(Info, msg.payload[0..@sizeOf(Info)]),
-                };
-            }
+            if (msg.payload.len != @sizeOf(Info)) return error.InfoSizeMismatch;
+            return .{
+                .fd = fd,
+                .info = std.mem.bytesToValue(Info, msg.payload[0..@sizeOf(Info)]),
+            };
         }
     }
     return error.Unexpected;
+}
+
+test "Info wire size is frozen" {
+    // Bumping this means version-skewed `zmx list` breaks. See doc comment
+    // on `Info` — add a new `Tag` instead of growing this struct.
+    try std.testing.expectEqual(@as(usize, 552), @sizeOf(Info));
+    // packed struct{u8,u32} backs to u40 → @sizeOf rounds to 8, not 5.
+    try std.testing.expectEqual(@as(usize, 8), @sizeOf(Header));
+}
+
+test "zeroed Info has no stack garbage in wire bytes" {
+    var info = std.mem.zeroes(Info);
+    info.clients_len = 3;
+    info.pid = 999;
+    info.task_exit_code = 7;
+    const bytes = std.mem.asBytes(&info);
+    // Tail padding after task_exit_code must be zero (asBytes ships it).
+    const last_field_end = @offsetOf(Info, "task_exit_code") + @sizeOf(u8);
+    for (bytes[last_field_end..]) |b| try std.testing.expectEqual(@as(u8, 0), b);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1766,14 +1766,14 @@ fn switchSesh(daemon: *Daemon, current_sesh: []const u8) !void {
         w.interface.flush() catch {};
         return error.SessionNotFound;
     }
-    const result = ipc.probeSession(daemon.alloc, socket_path) catch |err| {
+    const fd = ipc.connectSession(socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
         if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, current_sesh);
         return;
     };
-    defer posix.close(result.fd);
+    defer posix.close(fd);
 
-    ipc.send(result.fd, .Switch, next_session) catch |err| switch (err) {
+    ipc.send(fd, .Switch, next_session) catch |err| switch (err) {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
         else => return err,
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -30,8 +30,10 @@ fn zmxLogFn(
     log_system.log(level, scope, format, args);
 }
 
-var sigwinch_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
-var sigterm_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+/// Self-pipe woken by signal handlers. std.posix.poll loops on .INTR internally
+/// (PollError has no Interrupted member), so a signal that lands during poll()
+/// never surfaces; the handler writes a byte here and poll() wakes on POLLIN.
+var sig_pipe: [2]posix.fd_t = .{ -1, -1 };
 
 // https://github.com/ziglang/zig/blob/738d2be9d6b6ef3ff3559130c05159ef53336224/lib/std/posix.zig#L3505
 const O_NONBLOCK: usize = 1 << @bitOffsetOf(posix.O, "NONBLOCK");
@@ -53,6 +55,18 @@ fn parseSessionArg(alloc: std.mem.Allocator, raw: []const u8) !SessionMatch {
     }
     const name = try socket.getSeshName(alloc, raw);
     return .{ .name = name, .is_prefix = false };
+}
+
+fn openSignalPipe() !void {
+    sig_pipe = try posix.pipe2(.{ .CLOEXEC = true, .NONBLOCK = true });
+}
+
+fn drainSignalPipe() void {
+    var b: [16]u8 = undefined;
+    while (true) {
+        const n = posix.read(sig_pipe[0], &b) catch return;
+        if (n == 0) return;
+    }
 }
 
 pub fn main() !void {
@@ -694,8 +708,8 @@ const Daemon = struct {
         var should_create = !exists;
 
         if (exists) {
-            if (ipc.probeSession(self.alloc, self.socket_path)) |result| {
-                posix.close(result.fd);
+            if (ipc.connectSession(self.socket_path)) |fd| {
+                posix.close(fd);
                 if (self.command != null) {
                     std.log.warn(
                         "session already exists, ignoring command session={s}",
@@ -708,12 +722,12 @@ const Daemon = struct {
                     socket.cleanupStaleSocket(dir, self.session_name);
                     should_create = true;
                 },
-                // Probe didn't respond in time -- daemon may just be busy.
-                // The probe is only to decide create-vs-attach; the session
-                // exists, so proceed to attach rather than fail or orphan.
+                // Connect failed for an unusual reason. The check is only to
+                // decide create-vs-attach; the socket file exists, so proceed
+                // to attach rather than fail or orphan.
                 else => {
                     std.log.warn(
-                        "probe slow ({s}), proceeding to attach session={s}",
+                        "connect failed ({s}), proceeding to attach session={s}",
                         .{ @errorName(err), self.session_name },
                     );
                 },
@@ -1012,12 +1026,17 @@ const Daemon = struct {
     }
 
     pub fn handleInfo(self: *Daemon, client: *Client) !void {
-        const clients_len = self.clients.items.len - 1;
+        // zeroes() so asBytes() doesn't ship struct padding + unused cmd/cwd
+        // tail bytes (daemon stack contents) to clients.
+        var info = std.mem.zeroes(ipc.Info);
+        info.clients_len = self.clients.items.len - 1;
+        info.pid = self.pid;
+        info.created_at = self.created_at;
+        info.task_ended_at = self.task_ended_at orelse 0;
+        info.task_exit_code = self.task_exit_code orelse 0;
 
         // Build command string from args, re-quoting args that contain
         // shell-special characters so the displayed command is copy-pasteable.
-        var cmd_buf: [ipc.MAX_CMD_LEN]u8 = undefined;
-        var cmd_len: u16 = 0;
         const cur_cmd = self.command;
         if (cur_cmd) |args| {
             for (args, 0..) |arg, i| {
@@ -1029,40 +1048,27 @@ const Daemon = struct {
                 const src = quoted orelse arg;
 
                 const need = src.len + @as(usize, if (i > 0) 1 else 0);
-                if (cmd_len + need > ipc.MAX_CMD_LEN) {
+                if (info.cmd_len + need > ipc.MAX_CMD_LEN) {
                     const ellipsis = "...";
-                    if (cmd_len + ellipsis.len <= ipc.MAX_CMD_LEN) {
-                        @memcpy(cmd_buf[cmd_len..][0..ellipsis.len], ellipsis);
-                        cmd_len += ellipsis.len;
+                    if (info.cmd_len + ellipsis.len <= ipc.MAX_CMD_LEN) {
+                        @memcpy(info.cmd[info.cmd_len..][0..ellipsis.len], ellipsis);
+                        info.cmd_len += ellipsis.len;
                     }
                     break;
                 }
 
                 if (i > 0) {
-                    cmd_buf[cmd_len] = ' ';
-                    cmd_len += 1;
+                    info.cmd[info.cmd_len] = ' ';
+                    info.cmd_len += 1;
                 }
-                @memcpy(cmd_buf[cmd_len..][0..src.len], src);
-                cmd_len += @intCast(src.len);
+                @memcpy(info.cmd[info.cmd_len..][0..src.len], src);
+                info.cmd_len += @intCast(src.len);
             }
         }
 
-        // Copy cwd
-        var cwd_buf: [ipc.MAX_CWD_LEN]u8 = undefined;
-        const cwd_len: u16 = @intCast(@min(self.cwd.len, ipc.MAX_CWD_LEN));
-        @memcpy(cwd_buf[0..cwd_len], self.cwd[0..cwd_len]);
+        info.cwd_len = @intCast(@min(self.cwd.len, ipc.MAX_CWD_LEN));
+        @memcpy(info.cwd[0..info.cwd_len], self.cwd[0..info.cwd_len]);
 
-        const info = ipc.Info{
-            .clients_len = clients_len,
-            .pid = self.pid,
-            .cmd_len = cmd_len,
-            .cwd_len = cwd_len,
-            .cmd = cmd_buf,
-            .cwd = cwd_buf,
-            .created_at = self.created_at,
-            .task_ended_at = self.task_ended_at orelse 0,
-            .task_exit_code = self.task_exit_code orelse 0,
-        };
         try ipc.appendMessage(self.alloc, &client.write_buf, .Info, std.mem.asBytes(&info));
         client.has_pending_output = true;
     }
@@ -1617,13 +1623,13 @@ fn detachAll(cfg: *Cfg) !void {
         error.OutOfMemory => return err,
     };
     defer alloc.free(socket_path);
-    const result = ipc.probeSession(alloc, socket_path) catch |err| {
+    const fd = ipc.connectSession(socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
         if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, session_name);
         return;
     };
-    defer posix.close(result.fd);
-    ipc.send(result.fd, .DetachAll, "") catch |err| switch (err) {
+    defer posix.close(fd);
+    ipc.send(fd, .DetachAll, "") catch |err| switch (err) {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
         else => return err,
     };
@@ -1651,7 +1657,7 @@ fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
         w.interface.flush() catch {};
         return error.SessionNotFound;
     }
-    const result = ipc.probeSession(alloc, socket_path) catch |err| {
+    const fd = ipc.connectSession(socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
         var buf: [4096]u8 = undefined;
         var w = std.fs.File.stdout().writer(&buf);
@@ -1668,8 +1674,8 @@ fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
         return;
     };
 
-    defer posix.close(result.fd);
-    ipc.send(result.fd, .Kill, "") catch |err| switch (err) {
+    defer posix.close(fd);
+    ipc.send(fd, .Kill, "") catch |err| switch (err) {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
         else => return err,
     };
@@ -1702,15 +1708,15 @@ fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !voi
         w.interface.flush() catch {};
         return error.SessionNotFound;
     }
-    const result = ipc.probeSession(alloc, socket_path) catch |err| {
+    const fd = ipc.connectSession(socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
         if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, session_name);
         return;
     };
-    defer posix.close(result.fd);
+    defer posix.close(fd);
 
     const format_byte = [_]u8{@intFromEnum(format)};
-    ipc.send(result.fd, .History, &format_byte) catch |err| switch (err) {
+    ipc.send(fd, .History, &format_byte) catch |err| switch (err) {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
         else => return err,
     };
@@ -1719,14 +1725,14 @@ fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !voi
     defer sb.deinit();
 
     while (true) {
-        var poll_fds = [_]posix.pollfd{.{ .fd = result.fd, .events = posix.POLL.IN, .revents = 0 }};
+        var poll_fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
         const poll_result = posix.poll(&poll_fds, 5000) catch return;
         if (poll_result == 0) {
             std.log.err("timeout waiting for history response", .{});
             return;
         }
 
-        const n = sb.read(result.fd) catch return;
+        const n = sb.read(fd) catch return;
         if (n == 0) return;
 
         while (sb.next()) |msg| {
@@ -2103,7 +2109,10 @@ fn run(daemon: *Daemon, detached: bool, command_args: [][]const u8) !void {
         return error.CommandRequired;
     }
 
-    const client_sock = try socket.sessionConnect(daemon.socket_path);
+    const client_sock = ipc.connectSession(daemon.socket_path) catch |err| {
+        std.log.err("session not ready: {s}", .{@errorName(err)});
+        return error.SessionNotReady;
+    };
     defer posix.close(client_sock);
 
     var fds = try std.ArrayList(i32).initCapacity(alloc, 1);
@@ -2134,7 +2143,8 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
     const alloc = std.heap.c_allocator;
     defer posix.close(client_sock_fd);
 
-    setupSigwinchHandler();
+    try openSignalPipe();
+    installWakeHandler(posix.SIG.WINCH);
 
     // Make socket non-blocking to avoid blocking on writes
     var sock_flags = try posix.fcntl(client_sock_fd, posix.F.GETFL, 0);
@@ -2168,12 +2178,6 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
     defer _ = posix.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags) catch {};
 
     while (true) {
-        // Check for pending SIGWINCH
-        if (sigwinch_received.swap(false, .acq_rel)) {
-            const next_size = ipc.getTerminalSize(posix.STDOUT_FILENO);
-            try ipc.appendMessage(alloc, &sock_write_buf, .Resize, std.mem.asBytes(&next_size));
-        }
-
         poll_fds.clearRetainingCapacity();
 
         try poll_fds.append(alloc, .{
@@ -2193,6 +2197,8 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
             .revents = 0,
         });
 
+        try poll_fds.append(alloc, .{ .fd = sig_pipe[0], .events = posix.POLL.IN, .revents = 0 });
+
         if (stdout_buf.items.len > 0) {
             try poll_fds.append(alloc, .{
                 .fd = posix.STDOUT_FILENO,
@@ -2201,10 +2207,13 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
             });
         }
 
-        _ = posix.poll(poll_fds.items, -1) catch |err| {
-            if (err == error.Interrupted) continue; // EINTR from signal, loop again
-            return err;
-        };
+        _ = try posix.poll(poll_fds.items, -1);
+
+        if (poll_fds.items[2].revents & posix.POLL.IN != 0) {
+            drainSignalPipe();
+            const next_size = ipc.getTerminalSize(posix.STDOUT_FILENO);
+            try ipc.appendMessage(alloc, &sock_write_buf, .Resize, std.mem.asBytes(&next_size));
+        }
 
         // Handle stdin -> socket (Input)
         const inp_flags = (posix.POLL.IN | posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL);
@@ -2308,7 +2317,8 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
 fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
     std.log.info("daemon started session={s} pty_fd={d}", .{ daemon.session_name, pty_fd });
     daemon.pty_fd = pty_fd;
-    setupSigtermHandler();
+    try openSignalPipe();
+    installWakeHandler(posix.SIG.TERM);
     var poll_fds = try std.ArrayList(posix.pollfd).initCapacity(daemon.alloc, 8);
     defer poll_fds.deinit(daemon.alloc);
 
@@ -2323,14 +2333,6 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
     defer vt_stream.deinit();
 
     daemon_loop: while (daemon.running) {
-        if (sigterm_received.swap(false, .acq_rel)) {
-            std.log.info(
-                "SIGTERM received, shutting down gracefully session={s}",
-                .{daemon.session_name},
-            );
-            break :daemon_loop;
-        }
-
         poll_fds.clearRetainingCapacity();
 
         try poll_fds.append(daemon.alloc, .{
@@ -2349,6 +2351,8 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
             .revents = 0,
         });
 
+        try poll_fds.append(daemon.alloc, .{ .fd = sig_pipe[0], .events = posix.POLL.IN, .revents = 0 });
+
         for (daemon.clients.items) |client| {
             var events: i16 = posix.POLL.IN;
             if (client.has_pending_output) {
@@ -2361,10 +2365,16 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
             });
         }
 
-        _ = posix.poll(poll_fds.items, -1) catch |err| {
-            if (err == error.Interrupted) continue;
-            return err;
-        };
+        _ = try posix.poll(poll_fds.items, -1);
+
+        if (poll_fds.items[2].revents & posix.POLL.IN != 0) {
+            drainSignalPipe();
+            std.log.info(
+                "SIGTERM received, shutting down gracefully session={s}",
+                .{daemon.session_name},
+            );
+            break :daemon_loop;
+        }
 
         if (poll_fds.items[0].revents & (posix.POLL.ERR | posix.POLL.HUP | posix.POLL.NVAL) != 0) {
             std.log.err("server socket error revents={d}", .{poll_fds.items[0].revents});
@@ -2473,9 +2483,9 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
 
         var i: usize = daemon.clients.items.len;
         // Only iterate over clients that were present when poll_fds was constructed
-        // poll_fds contains [server, pty, client0, client1, ...]
-        // So number of clients in poll_fds is poll_fds.items.len - 2
-        const num_polled_clients = poll_fds.items.len - 2;
+        // poll_fds contains [server, pty, sig_pipe, client0, client1, ...]
+        // So number of clients in poll_fds is poll_fds.items.len - 3
+        const num_polled_clients = poll_fds.items.len - 3;
         if (i > num_polled_clients) {
             // If we have more clients than polled (i.e. we just accepted one), start from the
             // polled ones
@@ -2485,7 +2495,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
         clients_loop: while (i > 0) {
             i -= 1;
             const client = daemon.clients.items[i];
-            const revents = poll_fds.items[i + 2].revents;
+            const revents = poll_fds.items[i + 3].revents;
 
             if (revents & posix.POLL.IN != 0) {
                 const n = client.read_buf.read(client.socket_fd) catch |err| {
@@ -2564,33 +2574,22 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
     }
 }
 
-fn handleSigwinch(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
-    sigwinch_received.store(true, .release);
+fn wakeSignalPipe(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
+    const saved = std.c._errno().*;
+    _ = std.c.write(sig_pipe[1], "x", 1);
+    std.c._errno().* = saved;
 }
 
-fn handleSigterm(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
-    sigterm_received.store(true, .release);
-}
-
-// No SA_RESTART: we want the signal to interrupt poll() so the
-// loop can check the flag. On BSD/macOS, SA_RESTART makes poll restartable,
-// which would leave an idle daemon deaf to SIGTERM until other I/O wakes it.
-fn setupSigwinchHandler() void {
+// std.posix.poll retries EINTR internally, so SA_RESTART is moot — neither
+// setting wakes the loop. The handler writes to sig_pipe instead; poll()
+// wakes on its read end.
+fn installWakeHandler(sig: u6) void {
     const act: posix.Sigaction = .{
-        .handler = .{ .sigaction = handleSigwinch },
+        .handler = .{ .sigaction = wakeSignalPipe },
         .mask = posix.sigemptyset(),
         .flags = posix.SA.SIGINFO,
     };
-    posix.sigaction(posix.SIG.WINCH, &act, null);
-}
-
-fn setupSigtermHandler() void {
-    const act: posix.Sigaction = .{
-        .handler = .{ .sigaction = handleSigterm },
-        .mask = posix.sigemptyset(),
-        .flags = posix.SA.SIGINFO,
-    };
-    posix.sigaction(posix.SIG.TERM, &act, null);
+    posix.sigaction(sig, &act, null);
 }
 
 fn ignoreSigpipe() void {
@@ -2600,4 +2599,8 @@ fn ignoreSigpipe() void {
         .flags = 0,
     };
     posix.sigaction(posix.SIG.PIPE, &act, null);
+}
+
+test {
+    _ = ipc;
 }


### PR DESCRIPTION
## 1. Self-pipe wakeup for SIGWINCH/SIGTERM

### Problem

An idle daemon (no clients, no PTY traffic) ignores `SIGTERM` indefinitely. An idle attached client ignores `SIGWINCH` until the next keystroke or daemon output.

### Root cause
Two independent causes: 1) race between flag check and poll() 2)
`std.posix.poll` [retries `EINTR` internally](https://github.com/ziglang/zig/blob/738d2be9d6b6ef3ff3559130c05159ef53336224/lib/std/posix.zig) and `PollError` has no `Interrupted` member. Signals only ever worked because subsequent I/O woke poll().

### Fix

Self-pipe trick: `posix.pipe2(.{ .CLOEXEC, .NONBLOCK })`, one `wakeSignalPipe` handler writes a byte, pipe read-end sits at fixed `poll_fds[2]` in both loops. Resize / shutdown happen in the drain branch. Removes the now-redundant `sigwinch_received`/`sigterm_received` atomics and collapses `setupSig*Handler` → `installWakeHandler(sig)`.

Verified via strace: `SIGTERM` → handler `write(8,"x",1)` → `ppoll` wake on `[2]` → drain → exit, all <1ms

---

*The next proposed change is a draft; very open to more discussion*

## 2. Decouple IPC liveness from `Info` struct shape

### Problem

When `Info`'s layout changes between builds, an old client talking to a new daemon (or vice versa) fails every operation e.g. `kill`, `detach`, `attach`, `run` etc. etc. with an opaque `Unexpected`, even though none of those need `Info`.

### Design considerations

The framing layer (`Header{tag,len}` + non-exhaustive `Tag`) is already a protobuf-style TLV at message granularity. I think we can lean on that instead of adding a new versioning scheme.

**Extending later:** new stats ship as new `Tag` values alongside the frozen `.Info` reply. `probeSession` already loops and skips non-`.Info` messages, so today's client tolerates a future daemon that sends `.Info` + `.InfoExt`; old daemons' `_` arm tolerates a future client that asks for tags they don't know.

### Fix

- New `connectSession()` does connect-only liveness; 5 of 6 callers (`kill`, `detach`, `history`, `run`, `attach`) switch to it and survive `Info` changes.
- `probeSession()` keeps the `Info` round-trip for `list`, which now reports `InfoSizeMismatch` instead of `Unexpected` on skew.
- Hygiene: `clients_len` `usize`→`u64` (extern struct, fixed width); `handleInfo` zero-inits `Info` so `asBytes()` doesn't ship 7B tail padding + cmd/cwd stack garbage.

Tests freeze `@sizeOf(Info)=552` / `@sizeOf(Header)=8` and assert a zeroed `Info` ships zero padding.