### PR TITLE
Update fish completions for zmx v0.5.0

### DIFF
--- a/src/completions.zig
+++ b/src/completions.zig
@@ -118,24 +118,35 @@ const zsh_completions =
 const fish_completions =
     \\complete -c zmx -f
     \\
+    \\# zmx flags
+    \\complete -c zmx -x -n '__fish_is_nth_token 1' -s v -l version -d 'Show version'
+    \\complete -c zmx -x -n '__fish_is_nth_token 1' -s h -d 'Show help message'
+    \\
+    \\# zmx subcommands
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'a attach' -d 'Attach to session, creating if needed'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'r run' -d 'Send command without attaching'
-    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'd detach' -d 'Detach all clients from current session'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'wr write' -d 'Write stdin to file_path through the session'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'd detach' -d 'Detach all clients (ctrl+\ for current client)'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'l list' -d 'List active sessions'
-    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'c completions' -d 'Shell completion scripts'
-    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'k kill' -d 'Kill a session'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'k kill' -d 'Kill session and all attached clients'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'hi history' -d 'Output session scrollback'
-    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'v version' -d 'Show version'
-    \\complete -c zmx -s v -l version -d 'Show version'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'w wait' -d 'Wait for session tasks to complete'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 't tail' -d 'Follow session output'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'c completions' -d 'Shell completions (bash, zsh, fish)'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'v version' -d 'Show version'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'h help' -d 'Show help message'
-    \\complete -c zmx -s h -d 'Show help message'
     \\
-    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run k kill hi history w wait" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
+    \\# Complete session names and shells
+    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run wr write hi history" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
+    \\complete -c zmx -n "not __fish_is_nth_token 1; and __fish_seen_subcommand_from k kill w wait t tail" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\
     \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from c completions" -a 'bash zsh fish' -d Shell
     \\
+    \\# Subcommand flags
+    \\complete -c zmx -n "__fish_seen_subcommand_from r run" -s d -d 'Detach from the calling terminal; use `wait` to track its status'
+    \\complete -c zmx -n "__fish_seen_subcommand_from r run" -l fish -d 'Required when the session runs fish shell'
     \\complete -c zmx -n "__fish_seen_subcommand_from l list" -l short -d 'Short output'
+    \\complete -c zmx -n "__fish_seen_subcommand_from k kill" -l force -d 'Force kill'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l vt -d 'History format for escape sequences'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l html -d 'History format for escape sequences'
 ;


### PR DESCRIPTION
This pull request updates the Fish shell completion script for the `zmx` command with the latest v0.5.0 changes.

**Fish shell completion improvements:**

* Fixed completions for global flags (`-v`/`--version`, `-h`) such that they don't appear in the completions for subcommands, e.g. pressing tab when the command is `zmx a session ` should not complete with `-v` or `-h`.
* Added missing subcommands (`wr write`, `t tail`) and improved descriptions for several existing subcommands (e.g., `detach`, `kill`, `completions`).
* Added completion for multiple session names in commands `kill`, `wait`, and `tail`.
* Added flag completions for subcommands `run` (`-d`, `--fish`) and `kill` (`--force`).