### PR TITLE
Improve detach handling

### DIFF
--- a/src/completions.zig
+++ b/src/completions.zig
@@ -29,7 +29,7 @@ const bash_completions =
     \\  cur="${COMP_WORDS[COMP_CWORD]}"
     \\  prev="${COMP_WORDS[COMP_CWORD-1]}"
     \\
-    \\  local commands="attach run detach list completions kill history version help"
+    \\  local commands="attach run detach reset list completions kill history version help"
     \\
     \\  if [[ $COMP_CWORD -eq 1 ]]; then
     \\    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -73,6 +73,7 @@ const zsh_completions =
     \\        'attach:Attach to session, creating if needed'
     \\        'run:Send command without attaching'
     \\        'detach:Detach all clients from current session'
+    \\        'reset:Reset outer terminal after an abnormal zmx exit'
     \\        'list:List active sessions'
     \\        'completions:Shell completion scripts'
     \\        'kill:Kill a session'
@@ -127,6 +128,7 @@ const fish_completions =
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'r run' -d 'Send command without attaching'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'wr write' -d 'Write stdin to file_path through the session'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'd detach' -d 'Detach all clients (ctrl+\ for current client)'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a 'reset' -d 'Reset outer terminal after an abnormal zmx exit'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'l list' -d 'List active sessions'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'k kill' -d 'Kill session and all attached clients'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a 'hi history' -d 'Output session scrollback'

--- a/src/main.zig
+++ b/src/main.zig
@@ -32,6 +32,17 @@ fn zmxLogFn(
 
 var sigwinch_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
 var sigterm_received: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var client_exit_requested: std.atomic.Value(bool) = std.atomic.Value(bool).init(false);
+var client_exit_signum: std.atomic.Value(i32) = std.atomic.Value(i32).init(0);
+// Nesting counter for attach(). The session-switch path recurses into
+// attach(target), and each stack frame captures its own `orig_termios`
+// via tcgetattr -- on a nested attach that captures the RAW termios
+// set by the outer. If we re-raised the delivering signal at the inner
+// frame's LIFO-last defer we would kill the process before the outer
+// could restore the real original termios, leaving the user's terminal
+// stuck in raw mode. Tracking depth lets only the outermost attach do
+// the re-raise.
+var attach_depth: u8 = 0;
 
 // https://github.com/ziglang/zig/blob/738d2be9d6b6ef3ff3559130c05159ef53336224/lib/std/posix.zig#L3505
 const O_NONBLOCK: usize = 1 << @bitOffsetOf(posix.O, "NONBLOCK");
@@ -1663,6 +1674,28 @@ fn attach(daemon: *Daemon) !void {
     const result = try daemon.ensureSession();
     if (result.is_daemon) return;
 
+    // Install exit-signal handlers before touching any terminal state so
+    // that a signal-delivered termination still runs the cleanup defers
+    // below. Without this, default SIGHUP / SIGTERM / SIGINT (e.g. pane
+    // close, parent shell exit, sshd-sent HUP on network disconnect)
+    // terminates zmx without restoring termios, stdin F_SETFL, or the
+    // outer terminal modes — leaving the pane stuck in whatever state
+    // the inner shell/program enabled (most visibly, Kitty keyboard
+    // protocol turning letter keys into escape sequences).
+    setupClientExitHandlers();
+
+    // LIFO-last defer of this attach frame. Decrement the nesting
+    // counter and, if this is the outermost attach, re-raise any
+    // latched exit signal so the process exits with the conventional
+    // 128+signum status. On nested (session-switch) frames the outer
+    // frame's cleanup must still run before we can raise, so we skip
+    // the reraise here.
+    attach_depth += 1;
+    defer {
+        attach_depth -= 1;
+        if (attach_depth == 0) maybeReraiseExitSignal();
+    }
+
     const client_sock = try socket.sessionConnect(daemon.socket_path);
     std.log.info("attached session={s}", .{daemon.session_name});
     //  This is typically used with tcsetattr() to modify terminal settings.
@@ -1683,17 +1716,43 @@ fn attach(daemon: *Daemon) !void {
         if (stdin_is_tty) {
             _ = cross.c.tcsetattr(posix.STDIN_FILENO, cross.c.TCSAFLUSH, &orig_termios);
         }
-        // Reset terminal modes on detach:
-        // - Mouse: 1000=basic, 1002=button-event, 1003=any-event, 1006=SGR extended
-        // - 2004=bracketed paste, 1004=focus events, 1049=alt screen
-        // - 25h=show cursor
-        // NOTE: We intentionally do NOT clear screen or home cursor here because we dont
-        // want to corrupt any programs that rely on it including ghostty's session restore.
-        const restore_seq = "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" ++
+        // Reset terminal modes on detach. Covers state the inner shell or
+        // an inner program may have enabled on the outer terminal during
+        // the session. Must run on every exit path (including signal-based
+        // termination via setupClientExitHandlers) so the outer pane is
+        // not left in a corrupted mode.
+        //
+        // NOTE: We intentionally do NOT clear screen or home cursor here
+        // because we don't want to corrupt any programs that rely on that,
+        // including ghostty's session restore.
+        const restore_seq =
+            // Mouse tracking: 1000=basic, 1002=button-event,
+            // 1003=any-event, 1006=SGR extended.
+            "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" ++
+            // 2004=bracketed paste, 1004=focus events, 1049=alt screen.
             "\x1b[?2004l\x1b[?1004l\x1b[?1049l" ++
-            // Restore pre-attach Kitty keyboard protocol mode so Ctrl combos
-            // return to legacy encoding in the user's outer shell.
-            "\x1b[<u" ++
+            // xterm modifyOtherKeys protocol off. Enabled by many TUIs;
+            // leaves Ctrl+letter producing CSI 27;mod;key~ in the outer
+            // shell if not reset. See #124.
+            "\x1b[>4;0m" ++
+            // Kitty keyboard protocol restore. First clear the current
+            // stack entry's flags (CSI = 0 ; 1 u), then pop it (CSI < u).
+            // The defensive clear protects against terminals that don't
+            // zero on pop, and against the set/pop asymmetry when the
+            // session's serialized state was replayed on re-attach.
+            "\x1b[=0;1u\x1b[<u" ++
+            // Cursor shape (DECSCUSR) back to default. Inner programs
+            // like nvim often set a bar/underline cursor. See #86.
+            "\x1b[0 q" ++
+            // Scrolling region (DECSTBM) back to full screen. Alt-screen
+            // programs (less, vim) set margins that otherwise persist.
+            "\x1b[r" ++
+            // Close any open hyperlink (OSC 8 with empty params).
+            "\x1b]8;;\x07" ++
+            // Reset all SGR attributes so colors / bold / italic don't
+            // leak into the outer shell.
+            "\x1b[0m" ++
+            // Cursor visible.
             "\x1b[?25h";
         _ = posix.write(posix.STDOUT_FILENO, restore_seq) catch {};
     }
@@ -1995,6 +2054,13 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
     defer _ = posix.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags) catch {};
 
     while (true) {
+        // Check for a pending HUP / TERM / INT. Returning here unwinds
+        // through the defers so the outer terminal is restored on
+        // signal-delivered termination.
+        if (client_exit_requested.load(.acquire)) {
+            return ClientResult{ .kind = .detach, .session_name = null };
+        }
+
         // Check for pending SIGWINCH
         if (sigwinch_received.swap(false, .acq_rel)) {
             const next_size = ipc.getTerminalSize(posix.STDOUT_FILENO);
@@ -2028,10 +2094,20 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
             });
         }
 
-        _ = posix.poll(poll_fds.items, -1) catch |err| {
-            if (err == error.Interrupted) continue; // EINTR from signal, loop again
-            return err;
-        };
+        // Call poll directly instead of std.posix.poll so that EINTR is
+        // visible here. The std.posix.poll wrapper transparently retries
+        // on EINTR which swallows signal-based wakeups — leaving this
+        // loop deaf to HUP/TERM/INT when no other I/O is pending.
+        const poll_rc = posix.system.poll(
+            poll_fds.items.ptr,
+            @intCast(poll_fds.items.len),
+            -1,
+        );
+        switch (posix.errno(poll_rc)) {
+            .SUCCESS => {},
+            .INTR => continue,
+            else => |err| return posix.unexpectedErrno(err),
+        }
 
         // Handle stdin -> socket (Input)
         const inp_flags = (posix.POLL.IN | posix.POLL.HUP | posix.POLL.ERR | posix.POLL.NVAL);
@@ -2396,6 +2472,37 @@ fn handleSigterm(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c)
     sigterm_received.store(true, .release);
 }
 
+fn handleClientExit(signum: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
+    // Store signum before the flag so any reader that sees the flag
+    // also observes a populated signum via the release/acquire pairing.
+    client_exit_signum.store(signum, .release);
+    client_exit_requested.store(true, .release);
+}
+
+// Called from attach() as the LIFO-last defer of the outermost attach
+// frame. If the client loop exited because a HUP/TERM/INT/QUIT was
+// delivered, reset that signal's handler to its default and re-raise
+// so the process exits with the conventional 128 + signum status.
+// Orderly detach paths leave the signum at 0 and this is a no-op.
+fn maybeReraiseExitSignal() void {
+    const signum = client_exit_signum.load(.acquire);
+    if (signum == 0) return;
+
+    const dfl: posix.Sigaction = .{
+        .handler = .{ .handler = posix.SIG.DFL },
+        .mask = posix.sigemptyset(),
+        .flags = 0,
+    };
+    posix.sigaction(@intCast(signum), &dfl, null);
+
+    // raise() delivers the signal to this thread; with SIG_DFL for a
+    // Term-class signal the kernel terminates the process here.
+    std.posix.raise(@intCast(signum)) catch {};
+
+    // Backstop if raise somehow returns (e.g. signal became blocked).
+    std.process.exit(@intCast(128 + signum));
+}
+
 // No SA_RESTART: we want the signal to interrupt poll() so the
 // loop can check the flag. On BSD/macOS, SA_RESTART makes poll restartable,
 // which would leave an idle daemon deaf to SIGTERM until other I/O wakes it.
@@ -2409,12 +2516,46 @@ fn setupSigwinchHandler() void {
 }
 
 fn setupSigtermHandler() void {
+    // The daemon forked from a client that has already installed its
+    // exit handlers (session switch path: attach -> switchSesh ->
+    // recursive attach -> ensureSession fork). Reset HUP/INT/QUIT to
+    // defaults so the daemon doesn't inherit a handler that just sets a
+    // flag the daemon never reads. TERM we handle explicitly below.
+    const dfl: posix.Sigaction = .{
+        .handler = .{ .handler = posix.SIG.DFL },
+        .mask = posix.sigemptyset(),
+        .flags = 0,
+    };
+    posix.sigaction(posix.SIG.HUP, &dfl, null);
+    posix.sigaction(posix.SIG.INT, &dfl, null);
+    posix.sigaction(posix.SIG.QUIT, &dfl, null);
+
     const act: posix.Sigaction = .{
         .handler = .{ .sigaction = handleSigterm },
         .mask = posix.sigemptyset(),
         .flags = posix.SA.SIGINFO,
     };
     posix.sigaction(posix.SIG.TERM, &act, null);
+}
+
+// Client-side handler for SIGHUP / SIGTERM / SIGINT / SIGQUIT. On
+// a flag and let clientLoop exit normally so the cleanup defers in
+// attach() (termios restore, stdin F_SETFL restore, outer terminal
+// restore_seq) run before the process dies. Zig's `defer` does not run
+// on default signal termination, so without this the outer terminal is
+// left in whatever mode the inner session enabled — most visibly, Kitty
+// keyboard protocol making letter keys produce escape sequences.
+// Same no-SA_RESTART rationale as setupSigtermHandler.
+fn setupClientExitHandlers() void {
+    const act: posix.Sigaction = .{
+        .handler = .{ .sigaction = handleClientExit },
+        .mask = posix.sigemptyset(),
+        .flags = posix.SA.SIGINFO,
+    };
+    posix.sigaction(posix.SIG.HUP, &act, null);
+    posix.sigaction(posix.SIG.TERM, &act, null);
+    posix.sigaction(posix.SIG.INT, &act, null);
+    posix.sigaction(posix.SIG.QUIT, &act, null);
 }
 
 fn ignoreSigpipe() void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -58,9 +58,16 @@ const O_NONBLOCK: usize = 1 << @bitOffsetOf(posix.O, "NONBLOCK");
 // we don't want to corrupt any programs that rely on that, including
 // ghostty's session restore.
 const outer_terminal_restore_seq =
-    // Mouse tracking: 1000=basic, 1002=button-event, 1003=any-event,
-    // 1006=SGR extended.
-    "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" ++
+    // Mouse tracking off. 9=X10, 1000=basic, 1001=hilite, 1002=button-
+    // event, 1003=any-event, 1005=UTF-8 coords, 1006=SGR coords,
+    // 1015=urxvt coords, 1016=SGR-Pixels coords. All are idempotent
+    // resets (harmless on terminals that never had them enabled).
+    //
+    // Deliberately omits 1007 (mouse_alternate_scroll): Ghostty enables
+    // it by default, so a blanket `?1007l` would disable scroll-wheel-
+    // to-arrow-keys in alt-screen programs for the outer pane.
+    "\x1b[?9l\x1b[?1000l\x1b[?1001l\x1b[?1002l\x1b[?1003l" ++
+    "\x1b[?1005l\x1b[?1006l\x1b[?1015l\x1b[?1016l" ++
     // 2004=bracketed paste, 1004=focus events, 1049=alt screen.
     "\x1b[?2004l\x1b[?1004l\x1b[?1049l" ++
     // xterm modifyOtherKeys protocol off. Enabled by many TUIs;
@@ -540,6 +547,49 @@ test "Cfg.init uses custom modes from env vars" {
 
     try std.testing.expectEqual(@as(u32, 0o770), cfg.dir_mode);
     try std.testing.expectEqual(@as(u32, 0o660), cfg.log_mode);
+}
+
+test "outer_terminal_restore_seq covers expected modes" {
+    const must_contain = [_][]const u8{
+        // Mouse tracking family.
+        "\x1b[?9l",
+        "\x1b[?1000l",
+        "\x1b[?1001l",
+        "\x1b[?1002l",
+        "\x1b[?1003l",
+        "\x1b[?1005l",
+        "\x1b[?1006l",
+        "\x1b[?1015l",
+        "\x1b[?1016l",
+        // Other modes.
+        "\x1b[?2004l", // bracketed paste
+        "\x1b[?1004l", // focus events
+        "\x1b[?1049l", // alt screen
+        "\x1b[>4;0m",  // xterm modifyOtherKeys off
+        "\x1b[=0;1u", // kitty keyboard clear current entry
+        "\x1b[<u",    // kitty keyboard pop
+        "\x1b[0 q",   // DECSCUSR cursor reset
+        "\x1b[r",     // DECSTBM reset
+        "\x1b]8;;\x07", // close OSC 8 hyperlink
+        "\x1b[0m",    // SGR reset
+        "\x1b[?25h",  // cursor show
+    };
+    for (must_contain) |frag| {
+        std.testing.expect(
+            std.mem.indexOf(u8, outer_terminal_restore_seq, frag) != null,
+        ) catch |err| {
+            std.debug.print("missing restore_seq fragment: {s}\n", .{frag});
+            return err;
+        };
+    }
+
+    // mouse_alternate_scroll (DECSET 1007) is enabled by default in
+    // Ghostty. If we ever emit `\x1b[?1007l` here we'd regress the
+    // outer pane by turning off scroll-wheel-to-arrow-keys in
+    // alt-screen programs.
+    try std.testing.expect(
+        std.mem.indexOf(u8, outer_terminal_restore_seq, "\x1b[?1007l") == null,
+    );
 }
 
 /// Daemon is responsible for managing a zmx session.

--- a/src/main.zig
+++ b/src/main.zig
@@ -47,6 +47,46 @@ var attach_depth: u8 = 0;
 // https://github.com/ziglang/zig/blob/738d2be9d6b6ef3ff3559130c05159ef53336224/lib/std/posix.zig#L3505
 const O_NONBLOCK: usize = 1 << @bitOffsetOf(posix.O, "NONBLOCK");
 
+// Bytes written to the outer terminal to unwind modes the inner session
+// may have enabled during `zmx attach`. Shared between the client's
+// detach/cleanup defer and the standalone `zmx reset` subcommand for
+// recovering a pane whose client died before its defer ran — most
+// visibly, Kitty keyboard protocol turning letter keys into escape
+// sequences.
+//
+// NOTE: We intentionally do NOT clear screen or home cursor here because
+// we don't want to corrupt any programs that rely on that, including
+// ghostty's session restore.
+const outer_terminal_restore_seq =
+    // Mouse tracking: 1000=basic, 1002=button-event, 1003=any-event,
+    // 1006=SGR extended.
+    "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" ++
+    // 2004=bracketed paste, 1004=focus events, 1049=alt screen.
+    "\x1b[?2004l\x1b[?1004l\x1b[?1049l" ++
+    // xterm modifyOtherKeys protocol off. Enabled by many TUIs;
+    // leaves Ctrl+letter producing CSI 27;mod;key~ in the outer shell
+    // if not reset. See #124.
+    "\x1b[>4;0m" ++
+    // Kitty keyboard protocol restore. First clear the current stack
+    // entry's flags (CSI = 0 ; 1 u), then pop it (CSI < u). The
+    // defensive clear protects against terminals that don't zero on
+    // pop, and against the set/pop asymmetry when the session's
+    // serialized state was replayed on re-attach.
+    "\x1b[=0;1u\x1b[<u" ++
+    // Cursor shape (DECSCUSR) back to default. Inner programs like
+    // nvim often set a bar/underline cursor. See #86.
+    "\x1b[0 q" ++
+    // Scrolling region (DECSTBM) back to full screen. Alt-screen
+    // programs (less, vim) set margins that otherwise persist.
+    "\x1b[r" ++
+    // Close any open hyperlink (OSC 8 with empty params).
+    "\x1b]8;;\x07" ++
+    // Reset all SGR attributes so colors / bold / italic don't leak
+    // into the outer shell.
+    "\x1b[0m" ++
+    // Cursor visible.
+    "\x1b[?25h";
+
 const SessionMatch = struct {
     name: []const u8,
     is_prefix: bool,
@@ -105,6 +145,8 @@ pub fn main() !void {
         return printCompletions(shell);
     } else if (std.mem.eql(u8, cmd, "detach") or std.mem.eql(u8, cmd, "d")) {
         return detachAll(&cfg);
+    } else if (std.mem.eql(u8, cmd, "reset")) {
+        return reset();
     } else if (std.mem.eql(u8, cmd, "history") or std.mem.eql(u8, cmd, "hi")) {
         var session_name: ?[]const u8 = null;
         var format: util.HistoryFormat = .plain;
@@ -1148,6 +1190,7 @@ fn help() !void {
         \\  [hi]story <name> [--vt|--html]           Output session scrollback
         \\  [w]ait <name>...                         Wait for session tasks to complete
         \\  [t]ail <name>...                         Follow session output
+        \\  reset                                    Reset outer terminal after an abnormal zmx exit
         \\  [c]ompletions <shell>                    Shell completions (bash, zsh, fish)
         \\  [v]ersion                                Show version
         \\  [h]elp                                   Show this help
@@ -1209,6 +1252,19 @@ fn help() !void {
         \\    zmx run -d dev sleep 10
         \\    zmx wait dev
         \\    zmx wait dev other
+        \\
+        \\Reset:
+        \\  Emit the same outer-terminal-mode cleanup bytes that `attach`
+        \\  writes on detach. Useful for recovering a pane whose zmx client
+        \\  died without running its cleanup (e.g. SSH disconnect mid-session,
+        \\  OOM, a wrapper process closing) and was left with Kitty keyboard
+        \\  protocol enabled, the alt screen still active, etc.
+        \\
+        \\  Safe to run on a healthy pane: the bytes re-assert defaults.
+        \\  Does not clear the screen or scrollback.
+        \\
+        \\  Examples:
+        \\    zmx reset
         \\
         \\Environment variables:
         \\  SHELL                Default shell for new sessions
@@ -1521,6 +1577,14 @@ fn detachAll(cfg: *Cfg) !void {
     };
 }
 
+fn reset() !void {
+    // Emit the same mode-cleanup bytes that the client's detach path
+    // writes, so a user whose `zmx attach` died without running its
+    // cleanup (e.g. SSH disconnect mid-session, OOM, pane close on a
+    // wrapper process) can recover the pane without closing it.
+    _ = try posix.write(posix.STDOUT_FILENO, outer_terminal_restore_seq);
+}
+
 fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
@@ -1716,45 +1780,9 @@ fn attach(daemon: *Daemon) !void {
         if (stdin_is_tty) {
             _ = cross.c.tcsetattr(posix.STDIN_FILENO, cross.c.TCSAFLUSH, &orig_termios);
         }
-        // Reset terminal modes on detach. Covers state the inner shell or
-        // an inner program may have enabled on the outer terminal during
-        // the session. Must run on every exit path (including signal-based
-        // termination via setupClientExitHandlers) so the outer pane is
-        // not left in a corrupted mode.
-        //
-        // NOTE: We intentionally do NOT clear screen or home cursor here
-        // because we don't want to corrupt any programs that rely on that,
-        // including ghostty's session restore.
-        const restore_seq =
-            // Mouse tracking: 1000=basic, 1002=button-event,
-            // 1003=any-event, 1006=SGR extended.
-            "\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l" ++
-            // 2004=bracketed paste, 1004=focus events, 1049=alt screen.
-            "\x1b[?2004l\x1b[?1004l\x1b[?1049l" ++
-            // xterm modifyOtherKeys protocol off. Enabled by many TUIs;
-            // leaves Ctrl+letter producing CSI 27;mod;key~ in the outer
-            // shell if not reset. See #124.
-            "\x1b[>4;0m" ++
-            // Kitty keyboard protocol restore. First clear the current
-            // stack entry's flags (CSI = 0 ; 1 u), then pop it (CSI < u).
-            // The defensive clear protects against terminals that don't
-            // zero on pop, and against the set/pop asymmetry when the
-            // session's serialized state was replayed on re-attach.
-            "\x1b[=0;1u\x1b[<u" ++
-            // Cursor shape (DECSCUSR) back to default. Inner programs
-            // like nvim often set a bar/underline cursor. See #86.
-            "\x1b[0 q" ++
-            // Scrolling region (DECSTBM) back to full screen. Alt-screen
-            // programs (less, vim) set margins that otherwise persist.
-            "\x1b[r" ++
-            // Close any open hyperlink (OSC 8 with empty params).
-            "\x1b]8;;\x07" ++
-            // Reset all SGR attributes so colors / bold / italic don't
-            // leak into the outer shell.
-            "\x1b[0m" ++
-            // Cursor visible.
-            "\x1b[?25h";
-        _ = posix.write(posix.STDOUT_FILENO, restore_seq) catch {};
+        // See `outer_terminal_restore_seq` for the bytes written and the
+        // rationale for not clearing screen / homing cursor here.
+        _ = posix.write(posix.STDOUT_FILENO, outer_terminal_restore_seq) catch {};
     }
 
     if (stdin_is_tty) {

--- a/src/util.zig
+++ b/src/util.zig
@@ -563,13 +563,34 @@ pub fn serializeTerminalState(alloc: std.mem.Allocator, term: *ghostty_vt.Termin
         .tabstops = false, // tabstop restoration moves cursor after CUP, corrupting position
         .pwd = true,
         .keyboard = true,
-        .screen = .all,
+        // Screen extras default to `.all`, but with kitty_keyboard disabled:
+        // the formatter would emit `CSI = <flags> ; 1 u` (SET, which modifies
+        // the top of the outer terminal's kitty-keyboard stack in place),
+        // while the client emits `CSI < u` (POP) on detach. That mismatch
+        // corrupts any kitty-keyboard state the outer shell had pushed
+        // before zmx attached. We emit a balanced PUSH (`CSI > <flags> u`)
+        // manually below so the detach POP unwinds our addition cleanly.
+        .screen = .{
+            .cursor = true,
+            .style = true,
+            .hyperlink = true,
+            .protection = true,
+            .kitty_keyboard = false,
+            .charsets = true,
+        },
     };
 
     vis_fmt.format(&builder.writer) catch |err| {
         std.log.warn("failed to format terminal state err={s}", .{@errorName(err)});
         return null;
     };
+
+    // Kitty keyboard protocol PUSH. Pairs with the client's `CSI < u` POP
+    // on detach. Skip when flags are disabled (nothing to restore).
+    const kb_flags = term.screens.active.kitty_keyboard.current().int();
+    if (kb_flags != 0) {
+        builder.writer.print("\x1b[>{d}u", .{kb_flags}) catch {};
+    }
 
     const output = builder.writer.buffered();
     if (output.len == 0) return null;
@@ -994,6 +1015,62 @@ test "serializeTerminalState excludes synchronized output replay" {
     // but NOT synchronized output (DECSET 2026)
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?2004h") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?2026h") == null);
+}
+
+test "serializeTerminalState emits kitty keyboard PUSH not SET" {
+    const alloc = testing.allocator;
+
+    var term = try ghostty_vt.Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+
+    // Inner shell pushes kitty keyboard with disambiguate (flags=1).
+    try stream.nextSlice("\x1b[>1u");
+
+    // Sanity: ghostty-vt pushed onto its stack.
+    try testing.expectEqual(
+        @as(u5, 1),
+        term.screens.active.kitty_keyboard.current().int(),
+    );
+
+    const output = serializeTerminalState(alloc, &term) orelse
+        return error.TestUnexpectedNull;
+    defer alloc.free(output);
+
+    // Replay must use PUSH so the client's `CSI < u` POP on detach
+    // unwinds it cleanly without overwriting outer-shell state.
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b[>1u") != null);
+    // Must NOT use the formatter's default SET form, which mutates the
+    // outer terminal's top-of-stack entry in place.
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b[=1;1u") == null);
+}
+
+test "serializeTerminalState omits kitty keyboard PUSH when disabled" {
+    const alloc = testing.allocator;
+
+    var term = try ghostty_vt.Terminal.init(alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+
+    try stream.nextSlice("hello");
+
+    const output = serializeTerminalState(alloc, &term) orelse
+        return error.TestUnexpectedNull;
+    defer alloc.free(output);
+
+    // No kitty-keyboard state to restore -> no push emitted.
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b[>") == null);
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b[=") == null);
 }
 
 fn testCreateTerminal(alloc: std.mem.Allocator, cols: u16, rows: u16, vt_data: []const u8) !ghostty_vt.Terminal {


### PR DESCRIPTION
I've ended up in states where my terminal gets in a bad state after certain uncontrolled detach situations. Think it depends on the state the zmx session has been in and exactly how the detach happens (e.g. network interrupted, client going to sleep vs planned detach).

These are some attempts at improving this situation.