### PR TITLE
fix(daemon): reset leader fd on client disconnect

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -543,6 +543,14 @@ const Daemon = struct {
 
     pub fn closeClient(self: *Daemon, client: *Client, i: usize, shutdown_on_last: bool) bool {
         const fd = client.socket_fd;
+        // leader is disconnected, remove ref and let another client claim leader on input
+        if (self.leader_client_fd == client.socket_fd) {
+            std.log.info(
+                "unsetting leader session={s} fd={d}",
+                .{ self.session_name, client.socket_fd },
+            );
+            self.leader_client_fd = null;
+        }
         client.deinit();
         self.alloc.destroy(client);
         _ = self.clients.orderedRemove(i);
@@ -944,14 +952,6 @@ const Daemon = struct {
 
     pub fn handleDetach(self: *Daemon, client: *Client, i: usize) void {
         std.log.info("client detach session={s} fd={d}", .{ self.session_name, client.socket_fd });
-        // leader is trying to disconnect, remove ref and let another client claim leader on input
-        if (self.leader_client_fd == client.socket_fd) {
-            std.log.info(
-                "unsetting leader session={s} fd={d}",
-                .{ self.session_name, client.socket_fd },
-            );
-            self.leader_client_fd = null;
-        }
         _ = self.closeClient(client, i, false);
     }
 


### PR DESCRIPTION
Make sure leader fd is reset when the leader client disconnects abruptly
without going through 'Detach' IPC. Otherwise, the daemon may remember
wrong client fd as the leader and run all input from the client via
libghostty parser.

Fixes #135

NOTE: this currently doesn't address the issue when libghostty can't
parse the byte sequence and complains like this:

```
[warning] (parser): CSI colon or mixed separators only allowed for 'm'
command, got: terminal.Parser.Action{ .csi_dispatch = .{ .intermediates
= {  }, .params = { 57444, 1, 1 }, .params_sep = .{ .mask = 2 }, .final
= 117 } }
```
