### PR TITLE
feat: accept ls as list alias to help our muscle memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Use spec: https://common-changelog.org/
 
 ## Staged
 
+### Added
+
+- `zmx ls` is accepted as an alias for `zmx list`
+
 ## v0.5.0 - 2026-04-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Commands:
   [p]rint <name> <text...>                 Inject text into session display
   [wr]ite <name> <file_path>               Write stdin to file_path through the session
   [d]etach                                 Detach all clients (ctrl+\\ for current client)
-  [l]ist [--short]                         List active sessions
+  [l]ist|ls [--short]                      List active sessions
   [k]ill <name>... [--force]               Kill session and all attached clients
   [hi]story <name> [--vt|--html]           Output session scrollback
   [w]ait <name>...                         Wait for session tasks to complete

--- a/src/main.zig
+++ b/src/main.zig
@@ -85,7 +85,7 @@ pub fn main() !void {
         return printVersion(&cfg);
     } else if (std.mem.eql(u8, cmd, "help") or std.mem.eql(u8, cmd, "h") or std.mem.eql(u8, cmd, "-h")) {
         return help();
-    } else if (std.mem.eql(u8, cmd, "list") or std.mem.eql(u8, cmd, "l")) {
+    } else if (std.mem.eql(u8, cmd, "list") or std.mem.eql(u8, cmd, "l") or std.mem.eql(u8, cmd, "ls")) {
         const short = if (args.next()) |arg| std.mem.eql(u8, arg, "--short") else false;
         return list(&cfg, short);
     } else if (std.mem.eql(u8, cmd, "completions") or std.mem.eql(u8, cmd, "c")) {
@@ -1228,7 +1228,7 @@ fn help() !void {
         \\  [p]rint <name> <text...>                 Inject text into session display
         \\  [wr]ite <name> <file_path>               Write stdin to file_path through the session
         \\  [d]etach                                 Detach all clients (ctrl+\\ for current client)
-        \\  [l]ist [--short]                         List active sessions
+        \\  [l]ist|ls [--short]                      List active sessions
         \\  [k]ill <name>... [--force]               Kill session and all attached clients
         \\  [hi]story <name> [--vt|--html]           Output session scrollback
         \\  [w]ait <name>...                         Wait for session tasks to complete

--- a/test/session.bats
+++ b/test/session.bats
@@ -100,6 +100,12 @@ load test_helper
   [[ "$output" == *"no sessions found"* ]]
 }
 
+@test "ls aliases list" {
+  run "$ZMX" ls
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no sessions found"* ]]
+}
+
 @test "list: shows session details" {
   "$ZMX" run test-list -d echo hello
   wait_for_session test-list


### PR DESCRIPTION
## Summary

This is a small alias addition: accept `zmx ls` anywhere `zmx list` is accepted.

It keeps the existing `list` behavior, including `--short`, while making the common shell muscle memory work naturally for listing zmx sessions.

## Changes

- Add `ls` to the `list` command dispatch branch
- Document `[l]ist|ls` in help and README
- Add a changelog entry
- Add a Bats regression test for the alias

## Verification

- `zig build test`
- `zig build`
- `./zig-out/bin/zmx help | rg -F "[l]ist|ls"`
- Isolated `ZMX_DIR` smoke test for `./zig-out/bin/zmx ls`
