### PR TITLE
build: support Zig 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .zig-cache/
 zig-cache/
 zig-out/
+zig-pkg/
 Session*.*vim
 commit_msg
 *.sw?

--- a/build.zig
+++ b/build.zig
@@ -20,7 +20,7 @@ pub fn build(b: *std.Build) void {
     const git_sha = std.mem.trim(u8, b.runAllowFail(
         &.{ "git", "rev-parse", "--short", "HEAD" },
         &code,
-        .Inherit,
+        .inherit,
     ) catch "unknown", "\n");
 
     const options = b.addOptions();
@@ -33,6 +33,7 @@ pub fn build(b: *std.Build) void {
         .root_source_file = b.path("src/main.zig"),
         .target = target,
         .optimize = optimize,
+        .link_libc = true,
     });
     exe_mod.addOptions("build_options", options);
 
@@ -52,7 +53,6 @@ pub fn build(b: *std.Build) void {
             .name = "zmx",
             .root_module = exe_mod,
         });
-        exe.linkLibC();
         b.installArtifact(exe);
         const run_cmd = b.addRunArtifact(exe);
         run_cmd.step.dependOn(b.getInstallStep());
@@ -67,6 +67,7 @@ pub fn build(b: *std.Build) void {
             .root_source_file = b.path("src/test.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         });
         const test_dep = b.dependency("ghostty", .{
             .target = target,
@@ -98,7 +99,6 @@ pub fn build(b: *std.Build) void {
             .name = "zmx",
             .root_module = exe_mod,
         });
-        exe_check.linkLibC();
 
         // Finally we add the "check" step which will be detected
         // by ZLS and automatically enable Build-On-Save.
@@ -119,6 +119,7 @@ pub fn build(b: *std.Build) void {
                 .root_source_file = b.path("src/main.zig"),
                 .target = resolved,
                 .optimize = .ReleaseSafe,
+                .link_libc = true,
             });
             release_mod.addOptions("build_options", options);
 
@@ -133,7 +134,6 @@ pub fn build(b: *std.Build) void {
                 .name = "zmx",
                 .root_module = release_mod,
             });
-            release_exe.linkLibC();
 
             const os_name = @tagName(release_target.os_tag orelse .linux);
             const arch_name = @tagName(release_target.cpu_arch orelse .x86_64);
@@ -148,7 +148,7 @@ pub fn build(b: *std.Build) void {
 
             const shasum = b.addSystemCommand(&.{ "shasum", "-a", "256" });
             shasum.addFileArg(tarball);
-            const shasum_output = shasum.captureStdOut();
+            const shasum_output = shasum.captureStdOut(.{});
 
             const install_tar = b.addInstallFile(tarball, b.fmt("dist/{s}", .{tarball_name}));
             const install_sha = b.addInstallFile(

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,11 +2,11 @@
     .name = .zmx,
     .version = "0.5.0",
     .fingerprint = 0x28aad87005052b4e, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.15.2",
+    .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ghostty = .{
-            .url = "git+https://github.com/ghostty-org/ghostty.git?ref=HEAD#c74f6d56d1feef473033057bc0ff7e3f00cf6421",
-            .hash = "ghostty-1.3.2-dev-5UdBC8HuDgWFQtz8pKQ-0HH6z0Cb_PKbI0R7AunQhdDF",
+            .url = "git+https://github.com/cataggar/ghostty.git?ref=zig16#981eb65a2b63d27b422246d90f0613550eb60143",
+            .hash = "ghostty-1.3.2-dev-5UdBC1Ub0SLULb3HB6zhxI2uQNts__LHthzkTedKwe4R",
         },
     },
     .paths = .{

--- a/src/compat.zig
+++ b/src/compat.zig
@@ -1,0 +1,263 @@
+const std = @import("std");
+const posix = std.posix;
+const c = std.c;
+const env = @import("env.zig");
+
+pub const UnixAddr = struct {
+    addr: c.sockaddr.un,
+
+    pub fn init(path: []const u8) !UnixAddr {
+        if (path.len >= @typeInfo(@TypeOf(@as(c.sockaddr.un, undefined).path)).array.len) return error.NameTooLong;
+        var addr: c.sockaddr.un = .{ .path = undefined };
+        @memset(&addr.path, 0);
+        @memcpy(addr.path[0..path.len], path);
+        return .{ .addr = addr };
+    }
+
+    pub fn sockaddr(self: *UnixAddr) *posix.sockaddr {
+        return @ptrCast(&self.addr);
+    }
+
+    pub fn socklen(self: UnixAddr) posix.socklen_t {
+        _ = self;
+        return @sizeOf(c.sockaddr.un);
+    }
+};
+
+pub fn close(fd: posix.fd_t) void {
+    _ = c.close(fd);
+}
+
+pub const WriteError = error{
+    DiskQuota,
+    FileTooBig,
+    InputOutput,
+    NoSpaceLeft,
+    DeviceBusy,
+    InvalidArgument,
+    AccessDenied,
+    BrokenPipe,
+    ConnectionResetByPeer,
+    WouldBlock,
+    Unexpected,
+};
+
+pub fn write(fd: posix.fd_t, bytes: []const u8) WriteError!usize {
+    const rc = c.write(fd, bytes.ptr, bytes.len);
+    if (rc >= 0) return @intCast(rc);
+    return switch (c.errno(rc)) {
+        .AGAIN => error.WouldBlock,
+        .PIPE => error.BrokenPipe,
+        .INVAL => error.InvalidArgument,
+        .NOSPC => error.NoSpaceLeft,
+        .IO => error.InputOutput,
+        .ACCES => error.AccessDenied,
+        .CONNRESET => error.ConnectionResetByPeer,
+        .DQUOT => error.DiskQuota,
+        .FBIG => error.FileTooBig,
+        else => error.Unexpected,
+    };
+}
+
+pub const O_NONBLOCK: u32 = @bitCast(c.O{ .NONBLOCK = true });
+
+pub fn fcntl(fd: posix.fd_t, cmd: anytype, arg: u32) !u32 {
+    const rc = c.fcntl(fd, @as(c_int, cmd), @as(c_int, @intCast(arg)));
+    if (rc >= 0) return @intCast(rc);
+    return error.Unexpected;
+}
+
+pub fn sleep(ns: u64) void {
+    const duration: c.timespec = .{
+        .sec = @intCast(ns / std.time.ns_per_s),
+        .nsec = @intCast(ns % std.time.ns_per_s),
+    };
+    _ = c.nanosleep(&duration, null);
+}
+
+pub fn pipe2(flags: c.O) ![2]posix.fd_t {
+    var fds: [2]posix.fd_t = undefined;
+    if (c.pipe(&fds) < 0) return error.Unexpected;
+    errdefer close(fds[0]);
+    errdefer close(fds[1]);
+
+    const flag_bits: u32 = @bitCast(flags);
+    if (flag_bits & @as(u32, @bitCast(c.O{ .NONBLOCK = true })) != 0) {
+        for (fds) |fd| {
+            const fd_flags = try fcntl(fd, posix.F.GETFL, 0);
+            _ = try fcntl(fd, posix.F.SETFL, fd_flags | O_NONBLOCK);
+        }
+    }
+    if (flag_bits & @as(u32, @bitCast(c.O{ .CLOEXEC = true })) != 0) {
+        for (fds) |fd| {
+            const fd_flags = c.fcntl(fd, c.F.GETFD);
+            if (fd_flags < 0) return error.Unexpected;
+            if (c.fcntl(fd, c.F.SETFD, fd_flags | posix.FD_CLOEXEC) < 0) return error.Unexpected;
+        }
+    }
+
+    return fds;
+}
+
+pub fn socket(domain: u32, sock_type: u32, protocol: u32) !posix.fd_t {
+    const nonblock_bits: u32 = posix.SOCK.NONBLOCK;
+    const cloexec_bits: u32 = posix.SOCK.CLOEXEC;
+    const clean_type = sock_type & ~(nonblock_bits | cloexec_bits);
+    const rc = c.socket(@intCast(domain), @intCast(clean_type), @intCast(protocol));
+    if (rc < 0) return error.Unexpected;
+    errdefer close(rc);
+
+    if (sock_type & nonblock_bits != 0) {
+        const flags = try fcntl(rc, posix.F.GETFL, 0);
+        _ = try fcntl(rc, posix.F.SETFL, flags | O_NONBLOCK);
+    }
+    if (sock_type & cloexec_bits != 0) {
+        const flags = c.fcntl(rc, c.F.GETFD);
+        if (flags < 0) return error.Unexpected;
+        if (c.fcntl(rc, c.F.SETFD, flags | posix.FD_CLOEXEC) < 0) return error.Unexpected;
+    }
+
+    return rc;
+}
+
+pub const ConnectError = error{
+    ConnectionRefused,
+    WouldBlock,
+    Unexpected,
+};
+
+pub fn connect(fd: posix.fd_t, addr: *const posix.sockaddr, addrlen: posix.socklen_t) ConnectError!void {
+    const rc = c.connect(fd, addr, addrlen);
+    if (rc == 0) return;
+    return switch (c.errno(rc)) {
+        .CONNREFUSED => error.ConnectionRefused,
+        .AGAIN, .INPROGRESS => error.WouldBlock,
+        else => error.Unexpected,
+    };
+}
+
+pub fn bind(fd: posix.fd_t, addr: *const posix.sockaddr, addrlen: posix.socklen_t) !void {
+    const rc = c.bind(fd, addr, addrlen);
+    if (rc == 0) return;
+    return switch (c.errno(rc)) {
+        .ADDRINUSE => error.AddressInUse,
+        .ACCES => error.AccessDenied,
+        else => error.Unexpected,
+    };
+}
+
+pub fn listen(fd: posix.fd_t, backlog: u31) !void {
+    const rc = c.listen(fd, backlog);
+    if (rc == 0) return;
+    return error.Unexpected;
+}
+
+pub fn accept(fd: posix.fd_t, addr: ?*posix.sockaddr, addrlen: ?*posix.socklen_t, flags: u32) !posix.fd_t {
+    const rc = c.accept(fd, addr, addrlen);
+    if (rc < 0) return switch (c.errno(rc)) {
+        .AGAIN => error.WouldBlock,
+        else => error.Unexpected,
+    };
+    errdefer close(rc);
+
+    if (flags & posix.SOCK.NONBLOCK != 0) {
+        const fd_flags = try fcntl(rc, posix.F.GETFL, 0);
+        _ = try fcntl(rc, posix.F.SETFL, fd_flags | O_NONBLOCK);
+    }
+    if (flags & posix.SOCK.CLOEXEC != 0) {
+        const fd_flags = c.fcntl(rc, c.F.GETFD);
+        if (fd_flags < 0) return error.Unexpected;
+        if (c.fcntl(rc, c.F.SETFD, fd_flags | posix.FD_CLOEXEC) < 0) return error.Unexpected;
+    }
+
+    return rc;
+}
+
+pub fn fork() !posix.pid_t {
+    const rc = c.fork();
+    if (rc >= 0) return @intCast(rc);
+    return error.Unexpected;
+}
+
+pub fn setsid() !posix.pid_t {
+    const rc = c.setsid();
+    if (rc >= 0) return @intCast(rc);
+    return error.Unexpected;
+}
+
+pub fn dup2(old_fd: posix.fd_t, new_fd: posix.fd_t) !void {
+    const rc = c.dup2(old_fd, new_fd);
+    if (rc >= 0) return;
+    return error.Unexpected;
+}
+
+pub const ExecError = error{
+    FileNotFound,
+    AccessDenied,
+    NameTooLong,
+    NotDir,
+    InvalidExe,
+    SystemResources,
+    Unexpected,
+};
+
+fn execError(errno: c.E) ExecError {
+    return switch (errno) {
+        .NOENT => error.FileNotFound,
+        .ACCES => error.AccessDenied,
+        .NAMETOOLONG => error.NameTooLong,
+        .NOTDIR => error.NotDir,
+        .NOEXEC => error.InvalidExe,
+        .NOMEM => error.SystemResources,
+        else => error.Unexpected,
+    };
+}
+
+pub fn execveZ(path: [*:0]const u8, argv: [*:null]const ?[*:0]const u8, envp: [*:null]const ?[*:0]const u8) ExecError {
+    const rc = c.execve(path, argv, envp);
+    return execError(c.errno(rc));
+}
+
+pub fn execvpeZ(
+    alloc: std.mem.Allocator,
+    file_z: [*:0]const u8,
+    argv: [*:null]const ?[*:0]const u8,
+    envp: [*:null]const ?[*:0]const u8,
+) ExecError {
+    const file = std.mem.span(file_z);
+    if (std.mem.indexOfScalar(u8, file, '/') != null) {
+        return execveZ(file_z, argv, envp);
+    }
+
+    const path_env = env.get("PATH") orelse "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+    var saw_access_denied = false;
+    var dirs = std.mem.tokenizeScalar(u8, path_env, ':');
+    while (dirs.next()) |dir| {
+        const full_path = std.fmt.allocPrintSentinel(alloc, "{s}/{s}", .{ dir, file }, 0) catch return error.SystemResources;
+        const err = execveZ(full_path.ptr, argv, envp);
+        alloc.free(full_path);
+        switch (err) {
+            error.FileNotFound, error.NotDir => continue,
+            error.AccessDenied => {
+                saw_access_denied = true;
+                continue;
+            },
+            else => return err,
+        }
+    }
+    return if (saw_access_denied) error.AccessDenied else error.FileNotFound;
+}
+
+pub const WaitPidResult = struct {
+    pid: posix.pid_t,
+    status: u32,
+};
+
+pub fn waitpid(pid: posix.pid_t, flags: u32) WaitPidResult {
+    var status: c_int = 0;
+    const rc = c.waitpid(pid, &status, @intCast(flags));
+    return .{
+        .pid = @intCast(rc),
+        .status = @bitCast(status),
+    };
+}

--- a/src/cross.zig
+++ b/src/cross.zig
@@ -1,6 +1,5 @@
 const builtin = @import("builtin");
 const std = @import("std");
-const posix = std.posix;
 
 pub const c = switch (builtin.os.tag) {
     .macos => @cImport({
@@ -77,9 +76,8 @@ pub fn getForegroundProcessName(pty_fd: i32, buf: []u8) ?[]const u8 {
             // /proc/<pid>/comm contains just the process name + newline
             var path_buf: [64]u8 = undefined;
             const path = std.fmt.bufPrint(&path_buf, "/proc/{d}/comm", .{pgid}) catch return null;
-            const file = std.fs.openFileAbsolute(path, .{}) catch return null;
-            defer file.close();
-            const n = file.read(buf) catch return null;
+            const contents = std.Io.Dir.cwd().readFile(std.Options.debug_io, path, buf) catch return null;
+            const n = contents.len;
             // strip trailing newline
             const end = if (n > 0 and buf[n - 1] == '\n') n - 1 else n;
             return buf[0..end];

--- a/src/env.zig
+++ b/src/env.zig
@@ -1,0 +1,6 @@
+const std = @import("std");
+
+pub fn get(comptime name: [:0]const u8) ?[:0]const u8 {
+    const value = std.c.getenv(name) orelse return null;
+    return std.mem.span(value);
+}

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const posix = std.posix;
+const compat = @import("compat.zig");
 const cross = @import("cross.zig");
 const socket = @import("socket.zig");
 
@@ -106,7 +107,7 @@ pub fn appendMessage(
 fn writeAll(fd: i32, data: []const u8) !void {
     var index: usize = 0;
     while (index < data.len) {
-        const n = try posix.write(fd, data[index..]);
+        const n = try compat.write(fd, data[index..]);
         if (n == 0) return error.DiskQuota;
         index += n;
     }
@@ -217,7 +218,7 @@ pub fn probeSession(
 ) SessionProbeError!SessionProbeResult {
     const timeout_ms = 1000;
     const fd = try connectSession(socket_path);
-    errdefer posix.close(fd);
+    errdefer compat.close(fd);
 
     send(fd, .Info, "") catch return error.Unexpected;
 

--- a/src/log.zig
+++ b/src/log.zig
@@ -1,8 +1,8 @@
 const std = @import("std");
 
 pub const LogSystem = struct {
-    file: ?std.fs.File = null,
-    mutex: std.Thread.Mutex = .{},
+    file: ?std.Io.File = null,
+    mutex: std.atomic.Mutex = .unlocked,
     current_size: u64 = 0,
     max_size: u64 = 5 * 1024 * 1024, // 5MB
     path: []const u8 = "",
@@ -14,33 +14,37 @@ pub const LogSystem = struct {
         self.path = try alloc.dupe(u8, path);
         self.mode = mode;
 
-        const file = std.fs.openFileAbsolute(path, .{ .mode = .read_write }) catch |err| switch (err) {
-            error.FileNotFound => try std.fs.createFileAbsolute(
+        const io = std.Options.debug_io;
+        const file = std.Io.Dir.openFileAbsolute(io, path, .{ .mode = .read_write }) catch |err| switch (err) {
+            error.FileNotFound => try std.Io.Dir.createFileAbsolute(
+                io,
                 path,
-                .{ .read = true, .mode = @intCast(self.mode) },
+                .{
+                    .read = true,
+                    .permissions = .fromMode(@intCast(self.mode)),
+                },
             ),
             else => return err,
         };
 
-        const end_pos = try file.getEndPos();
-        try file.seekTo(end_pos);
+        const end_pos = try file.length(io);
         self.current_size = end_pos;
         self.file = file;
     }
 
     pub fn deinit(self: *LogSystem) void {
-        if (self.file) |f| f.close();
+        if (self.file) |f| f.close(std.Options.debug_io);
         if (self.path.len > 0) self.alloc.free(self.path);
     }
 
     pub fn log(
         self: *LogSystem,
         comptime level: std.log.Level,
-        comptime scope: @Type(.enum_literal),
+        comptime scope: @EnumLiteral(),
         comptime format: []const u8,
         args: anytype,
     ) void {
-        self.mutex.lock();
+        while (!self.mutex.tryLock()) std.atomic.spinLoopHint();
         defer self.mutex.unlock();
 
         if (self.file == null) {
@@ -54,7 +58,7 @@ pub const LogSystem = struct {
             };
         }
 
-        const now = std.time.milliTimestamp();
+        const now = std.Io.Timestamp.now(std.Options.debug_io, .real).toMilliseconds();
         const prefix = "[{d}] [{s}] ({s}): ";
         const scope_name = @tagName(scope);
         const level_name = level.asText();
@@ -70,10 +74,12 @@ pub const LogSystem = struct {
             const msg_len = std.fmt.count(format, args);
             const newline_len = 1;
             const total_len = prefix_len + msg_len + newline_len;
+            const write_pos = self.current_size;
             self.current_size += total_len;
 
             var buf: [4096]u8 = undefined;
-            var w = f.writerStreaming(&buf);
+            var w = f.writer(std.Options.debug_io, &buf);
+            w.seekTo(write_pos) catch unreachable;
             w.interface.print(prefix ++ format ++ "\n", prefix_args ++ args) catch {};
             w.interface.flush() catch {};
         }
@@ -81,21 +87,26 @@ pub const LogSystem = struct {
 
     fn rotate(self: *LogSystem) !void {
         if (self.file) |f| {
-            f.close();
+            f.close(std.Options.debug_io);
             self.file = null;
         }
 
         const old_path = try std.fmt.allocPrint(self.alloc, "{s}.old", .{self.path});
         defer self.alloc.free(old_path);
 
-        std.fs.renameAbsolute(self.path, old_path) catch |err| switch (err) {
+        std.Io.Dir.renameAbsolute(self.path, old_path, std.Options.debug_io) catch |err| switch (err) {
             error.FileNotFound => {},
             else => return err,
         };
 
-        self.file = try std.fs.createFileAbsolute(
+        self.file = try std.Io.Dir.createFileAbsolute(
+            std.Options.debug_io,
             self.path,
-            .{ .truncate = true, .read = true, .mode = @intCast(self.mode) },
+            .{
+                .truncate = true,
+                .read = true,
+                .permissions = .fromMode(@intCast(self.mode)),
+            },
         );
         self.current_size = 0;
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,6 +9,8 @@ const completions = @import("completions.zig");
 const util = @import("util.zig");
 const cross = @import("cross.zig");
 const socket = @import("socket.zig");
+const env = @import("env.zig");
+const compat = @import("compat.zig");
 
 pub const version = build_options.version;
 pub const git_sha = build_options.git_sha;
@@ -23,7 +25,7 @@ pub const std_options: std.Options = .{
 
 fn zmxLogFn(
     comptime level: std.log.Level,
-    comptime scope: @Type(.enum_literal),
+    comptime scope: @EnumLiteral(),
     comptime format: []const u8,
     args: anytype,
 ) void {
@@ -36,7 +38,7 @@ fn zmxLogFn(
 var sig_pipe: [2]posix.fd_t = .{ -1, -1 };
 
 // https://github.com/ziglang/zig/blob/738d2be9d6b6ef3ff3559130c05159ef53336224/lib/std/posix.zig#L3505
-const O_NONBLOCK: usize = 1 << @bitOffsetOf(posix.O, "NONBLOCK");
+const O_NONBLOCK: u32 = compat.O_NONBLOCK;
 
 const SessionMatch = struct {
     name: []const u8,
@@ -57,8 +59,13 @@ fn parseSessionArg(alloc: std.mem.Allocator, raw: []const u8) !SessionMatch {
     return .{ .name = name, .is_prefix = false };
 }
 
+fn getCwd(buf: []u8) []const u8 {
+    const len = std.process.currentPath(std.Options.debug_io, buf) catch return "";
+    return buf[0..len];
+}
+
 fn openSignalPipe() !void {
-    sig_pipe = try posix.pipe2(.{ .CLOEXEC = true, .NONBLOCK = true });
+    sig_pipe = try compat.pipe2(.{ .CLOEXEC = true, .NONBLOCK = true });
 }
 
 fn drainSignalPipe() void {
@@ -69,7 +76,7 @@ fn drainSignalPipe() void {
     }
 }
 
-pub fn main() !void {
+pub fn main(init: std.process.Init.Minimal) !void {
     // use c_allocator to avoid "reached unreachable code" panic in DebugAllocator when forking
     const alloc = std.heap.c_allocator;
 
@@ -79,7 +86,7 @@ pub fn main() !void {
     // covers the daemon.
     ignoreSigpipe();
 
-    var args = try std.process.argsWithAllocator(alloc);
+    var args = try std.process.Args.Iterator.initAllocator(init.args, alloc);
     defer args.deinit();
     _ = args.skip(); // skip program name
 
@@ -140,7 +147,7 @@ pub fn main() !void {
         }
 
         var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const cwd = std.posix.getcwd(&cwd_buf) catch "";
+        const cwd = getCwd(&cwd_buf);
 
         const sesh = try socket.getSeshName(alloc, session_name);
         defer alloc.free(sesh);
@@ -154,7 +161,7 @@ pub fn main() !void {
             .pid = undefined,
             .command = command,
             .cwd = cwd,
-            .created_at = @intCast(std.time.timestamp()),
+            .created_at = @intCast(std.Io.Timestamp.now(std.Options.debug_io, .real).toSeconds()),
             .leader_client_fd = null,
         };
         daemon.socket_path = socket.getSocketPath(alloc, cfg.socket_dir, sesh) catch |err| switch (err) {
@@ -179,7 +186,7 @@ pub fn main() !void {
         const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
 
         var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const cwd = std.posix.getcwd(&cwd_buf) catch "";
+        const cwd = getCwd(&cwd_buf);
 
         const sesh = try socket.getSeshName(alloc, session_name);
         defer alloc.free(sesh);
@@ -193,7 +200,7 @@ pub fn main() !void {
             .pid = undefined,
             .command = null,
             .cwd = cwd,
-            .created_at = @intCast(std.time.timestamp()),
+            .created_at = @intCast(std.Io.Timestamp.now(std.Options.debug_io, .real).toSeconds()),
             .is_task_mode = true,
             .leader_client_fd = null,
         };
@@ -239,7 +246,7 @@ pub fn main() !void {
         return send(&cfg, sesh, socket_path, text_parts.items, .Output);
     } else if (std.mem.eql(u8, cmd, "kill") or std.mem.eql(u8, cmd, "k")) {
         var stderr_buffer: [1024]u8 = undefined;
-        var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+        var stderr_writer = std.Io.File.stderr().writer(std.Options.debug_io, &stderr_buffer);
         const stderr = &stderr_writer.interface;
 
         var matchers: std.ArrayList(SessionMatch) = .empty;
@@ -361,7 +368,7 @@ pub fn main() !void {
         var client_socket_fds = try std.ArrayList(i32).initCapacity(alloc, resolved_names.items.len);
         defer {
             for (client_socket_fds.items) |client_fd| {
-                posix.close(client_fd);
+                compat.close(client_fd);
             }
             client_socket_fds.deinit(alloc);
         }
@@ -382,7 +389,7 @@ pub fn main() !void {
         if (file_path.len == 0) return error.FilePathRequired;
 
         var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-        const cwd = std.posix.getcwd(&cwd_buf) catch "";
+        const cwd = getCwd(&cwd_buf);
         const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
         const sesh = try socket.getSeshName(alloc, session_name);
         defer alloc.free(sesh);
@@ -396,7 +403,7 @@ pub fn main() !void {
             .pid = undefined,
             .command = null,
             .cwd = cwd,
-            .created_at = @intCast(std.time.timestamp()),
+            .created_at = @intCast(std.Io.Timestamp.now(std.Options.debug_io, .real).toSeconds()),
             .is_task_mode = true,
             .leader_client_fd = null,
         };
@@ -422,7 +429,7 @@ const Client = struct {
     write_buf: std.ArrayList(u8),
 
     pub fn deinit(self: *Client) void {
-        posix.close(self.socket_fd);
+        compat.close(self.socket_fd);
         self.read_buf.deinit();
         self.write_buf.deinit(self.alloc);
     }
@@ -443,12 +450,12 @@ const Cfg = struct {
         const log_dir = try std.fmt.allocPrint(alloc, "{s}/logs", .{socket_dir});
         errdefer alloc.free(log_dir);
 
-        const dir_mode = if (std.posix.getenv("ZMX_DIR_MODE")) |m|
+        const dir_mode = if (env.get("ZMX_DIR_MODE")) |m|
             std.fmt.parseInt(u32, m, 8) catch 0o750
         else
             0o750;
 
-        const log_mode = if (std.posix.getenv("ZMX_LOG_MODE")) |m|
+        const log_mode = if (env.get("ZMX_LOG_MODE")) |m|
             std.fmt.parseInt(u32, m, 8) catch 0o640
         else
             0o640;
@@ -466,12 +473,12 @@ const Cfg = struct {
     }
 
     fn socketDir(alloc: std.mem.Allocator) ![]const u8 {
-        const tmpdir = std.mem.trimRight(u8, posix.getenv("TMPDIR") orelse "/tmp", "/");
-        const uid = posix.getuid();
+        const tmpdir = std.mem.trimEnd(u8, env.get("TMPDIR") orelse "/tmp", "/");
+        const uid = std.c.getuid();
 
-        const socket_dir: []const u8 = if (posix.getenv("ZMX_DIR")) |zmxdir|
+        const socket_dir: []const u8 = if (env.get("ZMX_DIR")) |zmxdir|
             try alloc.dupe(u8, zmxdir)
-        else if (posix.getenv("XDG_RUNTIME_DIR")) |xdg_runtime|
+        else if (env.get("XDG_RUNTIME_DIR")) |xdg_runtime|
             try std.fmt.allocPrint(alloc, "{s}/zmx", .{xdg_runtime})
         else
             try std.fmt.allocPrint(alloc, "{s}/zmx-{d}", .{ tmpdir, uid });
@@ -486,12 +493,20 @@ const Cfg = struct {
     }
 
     pub fn mkdir(self: *Cfg) !void {
-        posix.mkdirat(posix.AT.FDCWD, self.socket_dir, @intCast(self.dir_mode)) catch |err| switch (err) {
+        std.Io.Dir.createDirAbsolute(
+            std.Options.debug_io,
+            self.socket_dir,
+            .fromMode(@intCast(self.dir_mode)),
+        ) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
 
-        posix.mkdirat(posix.AT.FDCWD, self.log_dir, @intCast(self.dir_mode)) catch |err| switch (err) {
+        std.Io.Dir.createDirAbsolute(
+            std.Options.debug_io,
+            self.log_dir,
+            .fromMode(@intCast(self.dir_mode)),
+        ) catch |err| switch (err) {
             error.PathAlreadyExists => {},
             else => return err,
         };
@@ -642,9 +657,9 @@ const Daemon = struct {
             for (cmd_args, 0..) |arg, i| {
                 argv[i] = try alloc.dupeZ(u8, arg);
             }
-            const err = std.posix.execvpeZ(argv[0].?, argv.ptr, std.c.environ);
+            const err = compat.execvpeZ(alloc, argv[0].?, argv.ptr, std.c.environ);
             std.log.err("execvpe failed: cmd={s} err={s}", .{ cmd_args[0], @errorName(err) });
-            std.posix.exit(1);
+            std.process.exit(1);
         }
 
         const shell = util.detectShell();
@@ -656,9 +671,9 @@ const Daemon = struct {
             0,
         );
         const argv = [_:null]?[*:0]const u8{ login_shell, null };
-        const err = std.posix.execveZ(shell, &argv, std.c.environ);
+        const err = compat.execveZ(shell, &argv, std.c.environ);
         std.log.err("execve failed: err={s}", .{@errorName(err)});
-        std.posix.exit(1);
+        std.process.exit(1);
     }
 
     /// spawnPty runs forkpty() and executes the shell or shell command the user provides.
@@ -684,7 +699,7 @@ const Daemon = struct {
             // errdefers that delete the parent's socket file).
             execChild(self) catch |err| {
                 std.log.err("child setup failed: {s}", .{@errorName(err)});
-                std.posix.exit(1);
+                std.process.exit(1);
             };
             unreachable; // execChild either execs or exits, never returns ok
         }
@@ -693,23 +708,23 @@ const Daemon = struct {
         std.log.info("pty spawned session={s} pid={d}", .{ self.session_name, pid });
 
         // make pty non-blocking
-        const flags = try posix.fcntl(master_fd, posix.F.GETFL, 0);
-        _ = try posix.fcntl(master_fd, posix.F.SETFL, flags | O_NONBLOCK);
+        const flags = try compat.fcntl(master_fd, posix.F.GETFL, 0);
+        _ = try compat.fcntl(master_fd, posix.F.SETFL, flags | O_NONBLOCK);
         return master_fd;
     }
 
     /// ensureSession "upserts" a session by checking if the unix socket exists already.
     /// If not it creates one and spawns the daemon.
     fn ensureSession(self: *Daemon) !EnsureSessionResult {
-        var dir = try std.fs.openDirAbsolute(self.cfg.socket_dir, .{});
-        defer dir.close();
+        var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, self.cfg.socket_dir, .{});
+        defer dir.close(std.Options.debug_io);
 
         const exists = try socket.sessionExists(dir, self.session_name);
         var should_create = !exists;
 
         if (exists) {
             if (ipc.connectSession(self.socket_path)) |fd| {
-                posix.close(fd);
+                compat.close(fd);
                 if (self.command != null) {
                     std.log.warn(
                         "session already exists, ignoring command session={s}",
@@ -739,10 +754,10 @@ const Daemon = struct {
             const server_sock_fd = try socket.createSocket(self.socket_path);
 
             // creates the daemon
-            const pid = try posix.fork();
+            const pid = try compat.fork();
             if (pid == 0) { // child (daemon)
                 // becomes the session leader and detaches process from its controlling terminal
-                _ = try posix.setsid();
+                _ = try compat.setsid();
 
                 log_system.deinit();
 
@@ -752,7 +767,8 @@ const Daemon = struct {
                 // keyword) stays open for the daemon's lifetime, causing
                 // the caller to hang waiting for EOF.
                 {
-                    const devnull = std.posix.open(
+                    const devnull = posix.openat(
+                        posix.AT.FDCWD,
                         "/dev/null",
                         .{ .ACCMODE = .RDWR },
                         0,
@@ -761,12 +777,12 @@ const Daemon = struct {
                         return err;
                     };
                     inline for (.{ posix.STDIN_FILENO, posix.STDOUT_FILENO, posix.STDERR_FILENO }) |fd| {
-                        _ = posix.dup2(devnull, fd) catch |err| {
+                        _ = compat.dup2(devnull, fd) catch |err| {
                             std.log.warn("dup2 /dev/null -> {d}: {s}", .{ fd, @errorName(err) });
                             return err;
                         };
                     }
-                    if (devnull > 2) posix.close(devnull);
+                    if (devnull > 2) compat.close(devnull);
                 }
 
                 // Close file descriptors inherited from the parent that the
@@ -781,7 +797,7 @@ const Daemon = struct {
                 // Skip server_sock_fd (needed for IPC) and dir.fd (needed to
                 // delete the socket file on shutdown).
                 {
-                    const dir_fd = @as(i32, @intCast(dir.fd));
+                    const dir_fd = @as(i32, @intCast(dir.handle));
                     var fd: i32 = 3;
                     while (fd < 64) : (fd += 1) {
                         if (fd == server_sock_fd or fd == dir_fd) continue;
@@ -806,19 +822,19 @@ const Daemon = struct {
                 // the inner block's defer takes ownership of cleanup to
                 // avoid double-closing server_sock_fd on daemonLoop error.
                 const pty_fd = self.spawnPty() catch |err| {
-                    posix.close(server_sock_fd);
-                    dir.deleteFile(self.session_name) catch {};
+                    compat.close(server_sock_fd);
+                    dir.deleteFile(std.Options.debug_io, self.session_name) catch {};
                     return err;
                 };
 
                 defer {
                     self.handleKill();
                     self.deinit();
-                    posix.close(pty_fd);
-                    _ = posix.waitpid(self.pid, 0);
-                    posix.close(server_sock_fd);
+                    compat.close(pty_fd);
+                    _ = compat.waitpid(self.pid, 0);
+                    compat.close(server_sock_fd);
                     std.log.info("deleting socket file session={s}", .{self.session_name});
-                    dir.deleteFile(self.session_name) catch |err| {
+                    dir.deleteFile(std.Options.debug_io, self.session_name) catch |err| {
                         std.log.warn("failed to delete socket file err={s}", .{@errorName(err)});
                     };
                 }
@@ -826,8 +842,8 @@ const Daemon = struct {
                 try daemonLoop(self, server_sock_fd, pty_fd);
                 return .{ .created = true, .is_daemon = true };
             }
-            posix.close(server_sock_fd);
-            std.Thread.sleep(10 * std.time.ns_per_ms);
+            compat.close(server_sock_fd);
+            compat.sleep(10 * std.time.ns_per_ms);
             return .{ .created = true, .is_daemon = false };
         }
 
@@ -1019,7 +1035,7 @@ const Daemon = struct {
         posix.kill(-self.pid, posix.SIG.HUP) catch |err| {
             std.log.warn("failed to send SIGHUP to pty child err={s}", .{@errorName(err)});
         };
-        std.Thread.sleep(500 * std.time.ns_per_ms);
+        compat.sleep(500 * std.time.ns_per_ms);
         posix.kill(-self.pid, posix.SIG.KILL) catch |err| {
             std.log.warn("failed to send SIGKILL to pty child err={s}", .{@errorName(err)});
         };
@@ -1080,7 +1096,7 @@ const Daemon = struct {
         payload: []const u8,
     ) !void {
         const format: util.HistoryFormat = if (payload.len > 0)
-            std.meta.intToEnum(util.HistoryFormat, payload[0]) catch .plain
+            std.enums.fromInt(util.HistoryFormat, payload[0]) orelse .plain
         else
             .plain;
         if (util.serializeTerminal(self.alloc, term, format)) |output| {
@@ -1201,7 +1217,7 @@ const Daemon = struct {
 
 fn printVersion(cfg: *Cfg) !void {
     var buf: [256]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
+    var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
     var ver = version;
     if (builtin.mode == .Debug) {
         ver = git_sha;
@@ -1216,7 +1232,7 @@ fn printVersion(cfg: *Cfg) !void {
 fn printCompletions(shell: completions.Shell) !void {
     const script = shell.getCompletionScript();
     var buf: [8192]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
+    var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
     try w.interface.print("{s}\n", .{script});
     try w.interface.flush();
 }
@@ -1336,13 +1352,13 @@ fn help() !void {
         \\
     ;
     var buf: [8192]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
+    var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
     try w.interface.print(help_text, .{});
     try w.interface.flush();
 }
 
 fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool) !u8 {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
 
@@ -1404,7 +1420,7 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
                     switch (msg.header.tag) {
                         .Ack => {
                             if (detached) {
-                                _ = posix.write(posix.STDOUT_FILENO, "command sent!\n") catch |err| blk: {
+                                _ = compat.write(posix.STDOUT_FILENO, "command sent!\n") catch |err| blk: {
                                     if (err == error.WouldBlock) break :blk 0;
                                     return err;
                                 };
@@ -1437,7 +1453,7 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
         }
 
         if (stdout_buf.items.len > 0) {
-            const n = posix.write(posix.STDOUT_FILENO, stdout_buf.items) catch |err| blk: {
+            const n = compat.write(posix.STDOUT_FILENO, stdout_buf.items) catch |err| blk: {
                 if (err == error.WouldBlock) break :blk 0;
                 return err;
             };
@@ -1459,16 +1475,16 @@ fn tail(client_socket_fds: std.ArrayList(i32), detached: bool, is_run_cmd: bool)
 }
 
 fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
 
     var stdout_buffer: [1024]u8 = undefined;
-    var stdout_writer = std.fs.File.stdout().writer(&stdout_buffer);
+    var stdout_writer = std.Io.File.stdout().writer(std.Options.debug_io, &stdout_buffer);
     const stdout = &stdout_writer.interface;
 
     var stderr_buffer: [1024]u8 = undefined;
-    var stderr_writer = std.fs.File.stderr().writer(&stderr_buffer);
+    var stderr_writer = std.Io.File.stderr().writer(std.Options.debug_io, &stderr_buffer);
     const stderr = &stderr_writer.interface;
 
     // Highest match count seen so far. Lets us distinguish "sessions haven't
@@ -1504,7 +1520,7 @@ fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
                 // waiting". Count it as done+failed so wait terminates.
                 try stderr.print(
                     "[{d}] task unreachable: {s} ({s})\n",
-                    .{ std.time.timestamp(), session.name, session.error_name orelse "unknown" },
+                    .{ std.Io.Timestamp.now(std.Options.debug_io, .real).toSeconds(), session.name, session.error_name orelse "unknown" },
                 );
                 try stderr.flush();
                 agg_exit_code = 1;
@@ -1514,7 +1530,7 @@ fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
             if (session.task_ended_at == 0) {
                 try stdout.print(
                     "[{d}] waiting task={s}\n",
-                    .{ std.time.timestamp(), session.name },
+                    .{ std.Io.Timestamp.now(std.Options.debug_io, .real).toSeconds(), session.name },
                 );
                 try stdout.flush();
                 continue;
@@ -1567,7 +1583,7 @@ fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
             }
         }
 
-        std.Thread.sleep(1000 * std.time.ns_per_ms);
+        compat.sleep(1000 * std.time.ns_per_ms);
     }
 
     if (agg_exit_code == 0) {
@@ -1605,13 +1621,13 @@ fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
 }
 
 fn list(cfg: *Cfg, short: bool) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
 
     const current_session = socket.getSeshNameFromEnv();
     var buf: [4096]u8 = undefined;
-    var stdout = std.fs.File.stdout().writer(&buf);
+    var stdout = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
 
     var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
     defer {
@@ -1624,7 +1640,7 @@ fn list(cfg: *Cfg, short: bool) !void {
     if (sessions.items.len == 0) {
         if (short) return;
         var errbuf: [4096]u8 = undefined;
-        var stderr = std.fs.File.stderr().writer(&errbuf);
+        var stderr = std.Io.File.stderr().writer(std.Options.debug_io, &errbuf);
         try stderr.interface.print("no sessions found in {s}\n", .{cfg.socket_dir});
         try stderr.interface.flush();
         return;
@@ -1639,7 +1655,7 @@ fn list(cfg: *Cfg, short: bool) !void {
 }
 
 fn detachAll(cfg: *Cfg) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
     const session_name = socket.getSeshNameFromEnv();
@@ -1648,8 +1664,8 @@ fn detachAll(cfg: *Cfg) !void {
         return;
     }
 
-    var dir = try std.fs.openDirAbsolute(cfg.socket_dir, .{});
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, cfg.socket_dir, .{});
+    defer dir.close(std.Options.debug_io);
 
     const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
         error.NameTooLong => return socket.printSessionNameTooLong(session_name, cfg.socket_dir),
@@ -1661,7 +1677,7 @@ fn detachAll(cfg: *Cfg) !void {
         if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, session_name);
         return;
     };
-    defer posix.close(fd);
+    defer compat.close(fd);
     ipc.send(fd, .DetachAll, "") catch |err| switch (err) {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
         else => return err,
@@ -1669,7 +1685,7 @@ fn detachAll(cfg: *Cfg) !void {
 }
 
 fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
 
@@ -1679,13 +1695,13 @@ fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
     };
     defer alloc.free(socket_path);
 
-    var dir = try std.fs.openDirAbsolute(cfg.socket_dir, .{});
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, cfg.socket_dir, .{});
+    defer dir.close(std.Options.debug_io);
 
     const exists = try socket.sessionExists(dir, session_name);
     if (!exists) {
         var buf: [4096]u8 = undefined;
-        var w = std.fs.File.stderr().writer(&buf);
+        var w = std.Io.File.stderr().writer(std.Options.debug_io, &buf);
         w.interface.print("error: session \"{s}\" does not exist\n", .{session_name}) catch {};
         w.interface.flush() catch {};
         return error.SessionNotFound;
@@ -1693,7 +1709,7 @@ fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
     const fd = ipc.connectSession(socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
         var buf: [4096]u8 = undefined;
-        var w = std.fs.File.stdout().writer(&buf);
+        var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
         if (force or err == error.ConnectionRefused) {
             socket.cleanupStaleSocket(dir, session_name);
             w.interface.print("cleaned up stale session {s}\n", .{session_name}) catch {};
@@ -1707,20 +1723,20 @@ fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
         return;
     };
 
-    defer posix.close(fd);
+    defer compat.close(fd);
     ipc.send(fd, .Kill, "") catch |err| switch (err) {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
         else => return err,
     };
 
     var buf: [100]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
+    var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
     try w.interface.print("killed session {s}\n", .{session_name});
     try w.interface.flush();
 }
 
 fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.DebugAllocator(.{}) = .init;
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
 
@@ -1730,13 +1746,13 @@ fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !voi
     };
     defer alloc.free(socket_path);
 
-    var dir = try std.fs.openDirAbsolute(cfg.socket_dir, .{});
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, cfg.socket_dir, .{});
+    defer dir.close(std.Options.debug_io);
 
     const exists = try socket.sessionExists(dir, session_name);
     if (!exists) {
         var buf: [4096]u8 = undefined;
-        var w = std.fs.File.stderr().writer(&buf);
+        var w = std.Io.File.stderr().writer(std.Options.debug_io, &buf);
         w.interface.print("error: session \"{s}\" does not exist\n", .{session_name}) catch {};
         w.interface.flush() catch {};
         return error.SessionNotFound;
@@ -1746,7 +1762,7 @@ fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !voi
         if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, session_name);
         return;
     };
-    defer posix.close(fd);
+    defer compat.close(fd);
 
     const format_byte = [_]u8{@intFromEnum(format)};
     ipc.send(fd, .History, &format_byte) catch |err| switch (err) {
@@ -1770,7 +1786,7 @@ fn history(cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !voi
 
         while (sb.next()) |msg| {
             if (msg.header.tag == .History) {
-                _ = posix.write(posix.STDOUT_FILENO, msg.payload) catch return;
+                _ = compat.write(posix.STDOUT_FILENO, msg.payload) catch return;
                 return;
             }
         }
@@ -1788,13 +1804,13 @@ fn switchSesh(daemon: *Daemon, current_sesh: []const u8) !void {
     };
     defer daemon.alloc.free(socket_path);
 
-    var dir = try std.fs.openDirAbsolute(daemon.cfg.socket_dir, .{});
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, daemon.cfg.socket_dir, .{});
+    defer dir.close(std.Options.debug_io);
 
     const exists = try socket.sessionExists(dir, current_sesh);
     if (!exists) {
         var buf: [4096]u8 = undefined;
-        var w = std.fs.File.stderr().writer(&buf);
+        var w = std.Io.File.stderr().writer(std.Options.debug_io, &buf);
         w.interface.print("error: session \"{s}\" does not exist\n", .{current_sesh}) catch {};
         w.interface.flush() catch {};
         return error.SessionNotFound;
@@ -1804,7 +1820,7 @@ fn switchSesh(daemon: *Daemon, current_sesh: []const u8) !void {
         if (err == error.ConnectionRefused) socket.cleanupStaleSocket(dir, current_sesh);
         return;
     };
-    defer posix.close(fd);
+    defer compat.close(fd);
 
     ipc.send(fd, .Switch, next_session) catch |err| switch (err) {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
@@ -1843,7 +1859,7 @@ fn attach(daemon: *Daemon) !void {
         }
         // Reset terminal modes on detach:
         const restore_seq = "\x1bc";
-        _ = posix.write(posix.STDOUT_FILENO, restore_seq) catch {};
+        _ = compat.write(posix.STDOUT_FILENO, restore_seq) catch {};
     }
 
     if (stdin_is_tty) {
@@ -1867,7 +1883,7 @@ fn attach(daemon: *Daemon) !void {
     // Clear screen before attaching. This provides a clean slate before
     // the session restore.
     const clear_seq = "\x1b[2J\x1b[H";
-    _ = try posix.write(posix.STDOUT_FILENO, clear_seq);
+    _ = try compat.write(posix.STDOUT_FILENO, clear_seq);
 
     const looper = try clientLoop(client_sock);
     switch (looper.kind) {
@@ -1875,7 +1891,7 @@ fn attach(daemon: *Daemon) !void {
         .switch_session => {
             if (looper.session_name) |session_name| {
                 var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;
-                const cwd = std.posix.getcwd(&cwd_buf) catch "";
+                const cwd = getCwd(&cwd_buf);
                 const target_path = socket.getSocketPath(
                     daemon.alloc,
                     daemon.cfg.socket_dir,
@@ -1898,7 +1914,7 @@ fn attach(daemon: *Daemon) !void {
                     .socket_path = target_path,
                     .pid = undefined,
                     .cwd = cwd,
-                    .created_at = @intCast(std.time.timestamp()),
+                    .created_at = @intCast(std.Io.Timestamp.now(std.Options.debug_io, .real).toSeconds()),
                     .leader_client_fd = null,
                 };
                 return attach(&target_daemon);
@@ -1909,7 +1925,7 @@ fn attach(daemon: *Daemon) !void {
 
 fn writeFile(daemon: *Daemon, file_path: []const u8) !void {
     var buf: [4096]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
+    var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
     const sesh_result = try daemon.ensureSession();
     if (sesh_result.is_daemon) return;
 
@@ -1942,8 +1958,8 @@ fn writeFile(daemon: *Daemon, file_path: []const u8) !void {
         ),
         error.OutOfMemory => return err,
     };
-    var dir = try std.fs.openDirAbsolute(daemon.cfg.socket_dir, .{});
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, daemon.cfg.socket_dir, .{});
+    defer dir.close(std.Options.debug_io);
 
     const result = ipc.probeSession(daemon.alloc, socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
@@ -1960,7 +1976,7 @@ fn writeFile(daemon: *Daemon, file_path: []const u8) !void {
         return;
     };
 
-    defer posix.close(result.fd);
+    defer compat.close(result.fd);
 
     // Build wire payload: [u32 path len][path bytes][file content]
     var wire_buf = try std.ArrayList(u8).initCapacity(
@@ -1998,7 +2014,7 @@ fn writeFile(daemon: *Daemon, file_path: []const u8) !void {
 fn send(cfg: *Cfg, session_name: []const u8, socket_path: []const u8, text_parts: [][]const u8, tag: ipc.Tag) !void {
     const alloc = std.heap.c_allocator;
     var buf: [4096]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
+    var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
 
     var payload = std.ArrayList(u8).empty;
     defer payload.deinit(alloc);
@@ -2011,7 +2027,7 @@ fn send(cfg: *Cfg, session_name: []const u8, socket_path: []const u8, text_parts
     } else {
         // Read from stdin when no text arguments provided.
         const stdin_fd = posix.STDIN_FILENO;
-        if (!std.posix.isatty(stdin_fd)) {
+        if (!try std.Io.File.stdin().isTty(std.Options.debug_io)) {
             while (true) {
                 var tmp: [4096]u8 = undefined;
                 const n = posix.read(stdin_fd, &tmp) catch |err| {
@@ -2032,8 +2048,8 @@ fn send(cfg: *Cfg, session_name: []const u8, socket_path: []const u8, text_parts
 
     if (payload.items.len == 0) return error.TextRequired;
 
-    var dir = try std.fs.openDirAbsolute(cfg.socket_dir, .{});
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, cfg.socket_dir, .{});
+    defer dir.close(std.Options.debug_io);
 
     const probe_result = ipc.probeSession(alloc, socket_path) catch |err| {
         std.log.err("session unresponsive: {s}", .{@errorName(err)});
@@ -2049,7 +2065,7 @@ fn send(cfg: *Cfg, session_name: []const u8, socket_path: []const u8, text_parts
         try w.interface.flush();
         return;
     };
-    defer posix.close(probe_result.fd);
+    defer compat.close(probe_result.fd);
 
     ipc.send(probe_result.fd, tag, payload.items) catch |err| switch (err) {
         error.ConnectionResetByPeer, error.BrokenPipe => return,
@@ -2060,7 +2076,7 @@ fn send(cfg: *Cfg, session_name: []const u8, socket_path: []const u8, text_parts
 fn run(daemon: *Daemon, detached: bool, command_args: [][]const u8) !void {
     const alloc = daemon.alloc;
     var buf: [4096]u8 = undefined;
-    var w = std.fs.File.stdout().writer(&buf);
+    var w = std.Io.File.stdout().writer(std.Options.debug_io, &buf);
 
     var cmd_to_send: ?[]const u8 = null;
     var allocated_cmd: ?[]u8 = null;
@@ -2099,7 +2115,7 @@ fn run(daemon: *Daemon, detached: bool, command_args: [][]const u8) !void {
         allocated_cmd = @constCast(cmd_to_send.?);
     } else {
         const stdin_fd = posix.STDIN_FILENO;
-        if (!std.posix.isatty(stdin_fd)) {
+        if (!try std.Io.File.stdin().isTty(std.Options.debug_io)) {
             var stdin_buf = try std.ArrayList(u8).initCapacity(alloc, 4096);
             defer stdin_buf.deinit(alloc);
 
@@ -2136,7 +2152,7 @@ fn run(daemon: *Daemon, detached: bool, command_args: [][]const u8) !void {
         std.log.err("session not ready: {s}", .{@errorName(err)});
         return error.SessionNotReady;
     };
-    defer posix.close(client_sock);
+    defer compat.close(client_sock);
 
     var fds = try std.ArrayList(i32).initCapacity(alloc, 1);
     defer fds.deinit(alloc);
@@ -2148,7 +2164,7 @@ fn run(daemon: *Daemon, detached: bool, command_args: [][]const u8) !void {
     };
 
     const exit_code = try tail(fds, detached, true);
-    posix.exit(exit_code);
+    std.process.exit(exit_code);
 }
 
 const ClientResult = struct {
@@ -2164,15 +2180,15 @@ const ClientResult = struct {
 fn clientLoop(client_sock_fd: i32) !ClientResult {
     // use c_allocator to avoid "reached unreachable code" panic in DebugAllocator when forking
     const alloc = std.heap.c_allocator;
-    defer posix.close(client_sock_fd);
+    defer compat.close(client_sock_fd);
 
     try openSignalPipe();
     installWakeHandler(posix.SIG.WINCH);
 
     // Make socket non-blocking to avoid blocking on writes
-    var sock_flags = try posix.fcntl(client_sock_fd, posix.F.GETFL, 0);
+    var sock_flags = try compat.fcntl(client_sock_fd, posix.F.GETFL, 0);
     sock_flags |= O_NONBLOCK;
-    _ = try posix.fcntl(client_sock_fd, posix.F.SETFL, sock_flags);
+    _ = try compat.fcntl(client_sock_fd, posix.F.SETFL, sock_flags);
 
     // Buffer for outgoing socket writes
     var sock_write_buf = try std.ArrayList(u8).initCapacity(alloc, 4096);
@@ -2196,9 +2212,9 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
     // Make stdin non-blocking. O_NONBLOCK is set on the open file description,
     // which is shared with the parent shell; restore on exit to avoid
     // corrupting the parent's stdin.
-    const stdin_orig_flags = try posix.fcntl(stdin_fd, posix.F.GETFL, 0);
-    _ = try posix.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags | O_NONBLOCK);
-    defer _ = posix.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags) catch {};
+    const stdin_orig_flags = try compat.fcntl(stdin_fd, posix.F.GETFL, 0);
+    _ = try compat.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags | O_NONBLOCK);
+    defer _ = compat.fcntl(stdin_fd, posix.F.SETFL, stdin_orig_flags) catch {};
 
     while (true) {
         poll_fds.clearRetainingCapacity();
@@ -2306,7 +2322,7 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
         // Handle socket write (flush buffered messages to daemon)
         if (poll_fds.items[1].revents & posix.POLL.OUT != 0) {
             if (sock_write_buf.items.len > 0) {
-                const n = posix.write(client_sock_fd, sock_write_buf.items) catch |err| blk: {
+                const n = compat.write(client_sock_fd, sock_write_buf.items) catch |err| blk: {
                     if (err == error.WouldBlock) break :blk 0;
                     if (err == error.ConnectionResetByPeer or err == error.BrokenPipe) {
                         return ClientResult{ .kind = .detach, .session_name = null };
@@ -2320,7 +2336,7 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
         }
 
         if (stdout_buf.items.len > 0) {
-            const n = posix.write(posix.STDOUT_FILENO, stdout_buf.items) catch |err| blk: {
+            const n = compat.write(posix.STDOUT_FILENO, stdout_buf.items) catch |err| blk: {
                 if (err == error.WouldBlock) break :blk 0;
                 return err;
             };
@@ -2403,7 +2419,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
             std.log.err("server socket error revents={d}", .{poll_fds.items[0].revents});
             break :daemon_loop;
         } else if (poll_fds.items[0].revents & posix.POLL.IN != 0) {
-            const client_fd = try posix.accept(
+            const client_fd = try compat.accept(
                 server_sock_fd,
                 null,
                 null,
@@ -2459,7 +2475,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                     if (daemon.is_task_mode and daemon.task_exit_code == null) {
                         if (util.findTaskExitMarker(buf[0..n])) |exit_code| {
                             daemon.task_exit_code = exit_code;
-                            daemon.task_ended_at = @intCast(std.time.timestamp());
+                            daemon.task_ended_at = @intCast(std.Io.Timestamp.now(std.Options.debug_io, .real).toSeconds());
 
                             std.log.info("task completed exit_code={d}", .{exit_code});
 
@@ -2492,7 +2508,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
 
         if (poll_fds.items[1].revents & posix.POLL.OUT != 0) {
             while (daemon.pty_write_buf.items.len > 0) {
-                const n = posix.write(pty_fd, daemon.pty_write_buf.items) catch |err| {
+                const n = compat.write(pty_fd, daemon.pty_write_buf.items) catch |err| {
                     if (err != error.WouldBlock) {
                         std.log.warn("pty write failed: {s}", .{@errorName(err)});
                         daemon.pty_write_buf.clearRetainingCapacity();
@@ -2572,7 +2588,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
 
             if (revents & posix.POLL.OUT != 0) {
                 // Flush pending output buffers
-                const n = posix.write(client.socket_fd, client.write_buf.items) catch |err| blk: {
+                const n = compat.write(client.socket_fd, client.write_buf.items) catch |err| blk: {
                     if (err == error.WouldBlock) break :blk 0;
                     // Error on write, close client
                     const last = daemon.closeClient(client, i, false);
@@ -2597,7 +2613,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
     }
 }
 
-fn wakeSignalPipe(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
+fn wakeSignalPipe(_: posix.SIG, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
     const saved = std.c._errno().*;
     _ = std.c.write(sig_pipe[1], "x", 1);
     std.c._errno().* = saved;
@@ -2606,7 +2622,7 @@ fn wakeSignalPipe(_: i32, _: *const posix.siginfo_t, _: ?*anyopaque) callconv(.c
 // std.posix.poll retries EINTR internally, so SA_RESTART is moot -- neither
 // setting wakes the loop. The handler writes to sig_pipe instead; poll()
 // wakes on its read end.
-fn installWakeHandler(sig: u6) void {
+fn installWakeHandler(sig: posix.SIG) void {
     const act: posix.Sigaction = .{
         .handler = .{ .sigaction = wakeSignalPipe },
         .mask = posix.sigemptyset(),

--- a/src/socket.zig
+++ b/src/socket.zig
@@ -1,12 +1,14 @@
 const std = @import("std");
 const posix = std.posix;
+const compat = @import("compat.zig");
+const env = @import("env.zig");
 
 pub fn getSeshPrefix() []const u8 {
-    return std.posix.getenv("ZMX_SESSION_PREFIX") orelse "";
+    return env.get("ZMX_SESSION_PREFIX") orelse "";
 }
 
 pub fn getSeshNameFromEnv() []const u8 {
-    return std.posix.getenv("ZMX_SESSION") orelse "";
+    return env.get("ZMX_SESSION") orelse "";
 }
 
 pub fn getSeshName(alloc: std.mem.Allocator, sesh: []const u8) ![]const u8 {
@@ -29,22 +31,22 @@ pub fn getSeshName(alloc: std.mem.Allocator, sesh: []const u8) ![]const u8 {
 }
 
 pub fn sessionConnect(sesh: []const u8) !i32 {
-    var unix_addr = try std.net.Address.initUnix(sesh);
-    const socket_fd = try posix.socket(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, 0);
-    errdefer posix.close(socket_fd);
-    try posix.connect(socket_fd, &unix_addr.any, unix_addr.getOsSockLen());
+    var unix_addr = try compat.UnixAddr.init(sesh);
+    const socket_fd = try compat.socket(posix.AF.UNIX, posix.SOCK.STREAM | posix.SOCK.CLOEXEC, 0);
+    errdefer compat.close(socket_fd);
+    try compat.connect(socket_fd, unix_addr.sockaddr(), unix_addr.socklen());
     return socket_fd;
 }
 
-pub fn cleanupStaleSocket(dir: std.fs.Dir, session_name: []const u8) void {
+pub fn cleanupStaleSocket(dir: std.Io.Dir, session_name: []const u8) void {
     std.log.warn("stale socket found, cleaning up session={s}", .{session_name});
-    dir.deleteFile(session_name) catch |err| {
+    dir.deleteFile(std.Options.debug_io, session_name) catch |err| {
         std.log.warn("failed to delete stale socket err={s}", .{@errorName(err)});
     };
 }
 
-pub fn sessionExists(dir: std.fs.Dir, name: []const u8) !bool {
-    const stat = dir.statFile(name) catch |err| switch (err) {
+pub fn sessionExists(dir: std.Io.Dir, name: []const u8) !bool {
+    const stat = dir.statFile(std.Options.debug_io, name, .{}) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
@@ -58,16 +60,16 @@ pub fn createSocket(fname: []const u8) !i32 {
     // AF.UNIX: Unix domain socket for local IPC with client processes
     // SOCK.STREAM: Reliable, bidirectional communication
     // SOCK.NONBLOCK: Set socket to non-blocking
-    const fd = try posix.socket(
+    const fd = try compat.socket(
         posix.AF.UNIX,
         posix.SOCK.STREAM | posix.SOCK.NONBLOCK | posix.SOCK.CLOEXEC,
         0,
     );
-    errdefer posix.close(fd);
+    errdefer compat.close(fd);
 
-    var unix_addr = try std.net.Address.initUnix(fname);
-    try posix.bind(fd, &unix_addr.any, unix_addr.getOsSockLen());
-    try posix.listen(fd, 128);
+    var unix_addr = try compat.UnixAddr.init(fname);
+    try compat.bind(fd, unix_addr.sockaddr(), unix_addr.socklen());
+    try compat.listen(fd, 128);
     return fd;
 }
 
@@ -95,7 +97,7 @@ pub fn getSocketPath(
 
 pub fn printSessionNameTooLong(session_name: []const u8, socket_dir: []const u8) void {
     var buf: [4096]u8 = undefined;
-    var w = std.fs.File.stderr().writer(&buf);
+    var w = std.Io.File.stderr().writer(std.Options.debug_io, &buf);
     if (maxSessionNameLen(socket_dir)) |max_len| {
         w.interface.print(
             "error: session name is too long ({d} bytes, max {d} for socket directory \"{s}\")\n",

--- a/src/util.zig
+++ b/src/util.zig
@@ -3,6 +3,8 @@ const posix = std.posix;
 const ghostty_vt = @import("ghostty-vt");
 const ipc = @import("ipc.zig");
 const socket = @import("socket.zig");
+const env = @import("env.zig");
+const compat = @import("compat.zig");
 const testing = std.testing;
 
 pub const SessionEntry = struct {
@@ -32,13 +34,13 @@ pub fn get_session_entries(
     alloc: std.mem.Allocator,
     socket_dir: []const u8,
 ) !std.ArrayList(SessionEntry) {
-    var dir = try std.fs.openDirAbsolute(socket_dir, .{ .iterate = true });
-    defer dir.close();
+    var dir = try std.Io.Dir.openDirAbsolute(std.Options.debug_io, socket_dir, .{ .iterate = true });
+    defer dir.close(std.Options.debug_io);
     var iter = dir.iterate();
 
     var sessions = try std.ArrayList(SessionEntry).initCapacity(alloc, 30);
 
-    while (try iter.next()) |entry| {
+    while (try iter.next(std.Options.debug_io)) |entry| {
         const exists = socket.sessionExists(dir, entry.name) catch continue;
         if (exists) {
             const name = try alloc.dupe(u8, entry.name);
@@ -69,7 +71,7 @@ pub fn get_session_entries(
                 }
                 continue;
             };
-            posix.close(result.fd);
+            compat.close(result.fd);
 
             // Extract cmd and cwd from the fixed-size arrays. Lengths come
             // off the wire (u16 range), so clamp to the actual array size.
@@ -635,7 +637,7 @@ pub fn serializeTerminal(
 }
 
 pub fn detectShell() [:0]const u8 {
-    return std.posix.getenv("SHELL") orelse "/bin/sh";
+    return env.get("SHELL") orelse "/bin/sh";
 }
 
 /// Formats a session entry for list output (only the name when `short` is


### PR DESCRIPTION
## Summary
- update build.zig and build.zig.zon for Zig 0.16
- migrate source to Zig 0.16 std.Io/process/POSIX APIs
- add small compatibility helpers for removed POSIX wrappers and ignore generated zig-pkg cache

## Validation
- zig build check --summary all
- zig build test --summary all