### PR TITLE
fix: handle run help flag

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -100,10 +100,19 @@ pub fn main() !void {
     } else if (std.mem.eql(u8, cmd, "help") or std.mem.eql(u8, cmd, "h") or std.mem.eql(u8, cmd, "-h")) {
         return help();
     } else if (std.mem.eql(u8, cmd, "list") or std.mem.eql(u8, cmd, "l") or std.mem.eql(u8, cmd, "ls")) {
-        const short = if (args.next()) |arg| std.mem.eql(u8, arg, "--short") else false;
+        var short = false;
+        if (args.next()) |arg| {
+            if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+                return help();
+            }
+            short = std.mem.eql(u8, arg, "--short");
+        }
         return list(&cfg, short);
     } else if (std.mem.eql(u8, cmd, "completions") or std.mem.eql(u8, cmd, "c")) {
         const arg = args.next() orelse return;
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+            return help();
+        }
         const shell = completions.Shell.fromString(arg) orelse return;
         return printCompletions(shell);
     } else if (std.mem.eql(u8, cmd, "detach") or std.mem.eql(u8, cmd, "d")) {
@@ -112,7 +121,9 @@ pub fn main() !void {
         var session_name: ?[]const u8 = null;
         var format: util.HistoryFormat = .plain;
         while (args.next()) |arg| {
-            if (std.mem.eql(u8, arg, "--vt")) {
+            if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
+                return help();
+            } else if (std.mem.eql(u8, arg, "--vt")) {
                 format = .vt;
             } else if (std.mem.eql(u8, arg, "--html")) {
                 format = .html;
@@ -126,6 +137,9 @@ pub fn main() !void {
         return history(&cfg, sesh, format);
     } else if (std.mem.eql(u8, cmd, "attach") or std.mem.eql(u8, cmd, "a")) {
         const session_name = args.next() orelse "";
+        if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+            return help();
+        }
 
         var command_args: std.ArrayList([]const u8) = .empty;
         defer command_args.deinit(alloc);
@@ -208,6 +222,9 @@ pub fn main() !void {
         return run(&daemon, detached, cmd_args_raw.items);
     } else if (std.mem.eql(u8, cmd, "send") or std.mem.eql(u8, cmd, "s")) {
         const session_name = args.next() orelse "";
+        if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+            return help();
+        }
         if (session_name.len == 0) return error.SessionNameRequired;
 
         var text_parts: std.ArrayList([]const u8) = .empty;
@@ -225,6 +242,9 @@ pub fn main() !void {
         return send(&cfg, sesh, socket_path, text_parts.items, .Input);
     } else if (std.mem.eql(u8, cmd, "print") or std.mem.eql(u8, cmd, "p")) {
         const session_name = args.next() orelse "";
+        if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+            return help();
+        }
         if (session_name.len == 0) return error.SessionNameRequired;
 
         var text_parts: std.ArrayList([]const u8) = .empty;
@@ -254,6 +274,9 @@ pub fn main() !void {
         }
         var force = false;
         while (args.next()) |session_name| {
+            if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+                return help();
+            }
             if (std.mem.eql(u8, session_name, "--force")) {
                 force = true;
                 continue;
@@ -297,6 +320,9 @@ pub fn main() !void {
             matchers.deinit(alloc);
         }
         while (args.next()) |session_name| {
+            if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+                return help();
+            }
             const m = try parseSessionArg(alloc, session_name);
             try matchers.append(alloc, m);
         }
@@ -313,6 +339,9 @@ pub fn main() !void {
             matchers.deinit(alloc);
         }
         while (args.next()) |session_name| {
+            if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+                return help();
+            }
             const m = try parseSessionArg(alloc, session_name);
             try matchers.append(alloc, m);
         }
@@ -380,8 +409,14 @@ pub fn main() !void {
         _ = try tail(client_socket_fds, false, false);
     } else if (std.mem.eql(u8, cmd, "write") or std.mem.eql(u8, cmd, "wr")) {
         const session_name = args.next() orelse "";
+        if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+            return help();
+        }
         if (session_name.len == 0) return error.SessionNameRequired;
         const file_path = args.next() orelse "";
+        if (std.mem.eql(u8, file_path, "--help") or std.mem.eql(u8, file_path, "-h")) {
+            return help();
+        }
         if (file_path.len == 0) return error.FilePathRequired;
 
         var cwd_buf: [std.fs.max_path_bytes]u8 = undefined;

--- a/src/main.zig
+++ b/src/main.zig
@@ -165,6 +165,9 @@ pub fn main() !void {
         return attach(&daemon);
     } else if (std.mem.eql(u8, cmd, "run") or std.mem.eql(u8, cmd, "r")) {
         const session_name = args.next() orelse "";
+        if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
+            return help();
+        }
 
         var cmd_args_raw: std.ArrayList([]const u8) = .empty;
         defer cmd_args_raw.deinit(alloc);

--- a/test/session.bats
+++ b/test/session.bats
@@ -60,6 +60,23 @@ load test_helper
   [[ "$output" != *"--help"* ]]
 }
 
+@test "subcommands handle --help and -h without side effects" {
+  for cmd in attach send print write kill wait tail history list completions; do
+    run "$ZMX" "$cmd" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+
+    run "$ZMX" "$cmd" -h
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+  done
+
+  run "$ZMX" list --short
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"--help"* ]]
+  [[ "$output" != *"-h"* ]]
+}
+
 # ============================================================================
 # Send (raw PTY input)
 # ============================================================================

--- a/test/session.bats
+++ b/test/session.bats
@@ -50,6 +50,16 @@ load test_helper
   [ "$status" -ne 0 ]
 }
 
+@test "run --help shows help without creating a session" {
+  run "$ZMX" run --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+
+  run "$ZMX" list --short
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"--help"* ]]
+}
+
 # ============================================================================
 # Send (raw PTY input)
 # ============================================================================


### PR DESCRIPTION
Fixes #123

## Summary
- Treat `zmx run --help` and `zmx run -h` as help requests instead of session names
- Add a regression test that checks `--help` is not created as a session

## Testing
- `PATH=/tmp/proj/toolchains/zig-linux-x86_64-0.15.2:$PATH zig build -j2`
- `PATH=/tmp/proj/toolchains/zig-linux-x86_64-0.15.2:$PATH zig build test -j2`
- `PATH=/tmp/proj/toolchains/zig-linux-x86_64-0.15.2:$PATH zig fmt --check src/main.zig`
- Manual: `ZMX_DIR=$(mktemp -d) timeout 5 ./zig-out/bin/zmx run --help`