### PR TITLE
Fix zsh completion autoload registration

### DIFF
--- a/src/completions.zig
+++ b/src/completions.zig
@@ -56,6 +56,7 @@ const bash_completions =
 ;
 
 const zsh_completions =
+    \\#compdef zmx
     \\_zmx() {
     \\  local context state state_descr line
     \\  typeset -A opt_args


### PR DESCRIPTION
I hit a bug when zmx completions wouldn't load in zsh on macOS. I installed zmx with Homebrew. Looks like adding `#compdef zmx` is required for completions to load. As soon as I added the line to `/opt/homebrew/share/zsh/site-functions/_zmx` and reloaded completions, everything worked.