### PR TITLE
Keep logs in XDG_STATE_HOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,14 @@ This is particularly useful when running `zmx` as a system service with a shared
 
 ## debugging
 
-We store global logs for cli commands in `{socket_dir}/logs/zmx.log`. We store session-specific logs in `{socket_dir}/logs/{session_name}.log`. Right now they are enabled by default and cannot be disabled. The idea here is to help with initial development until we reach a stable state.
+We store global logs for cli commands in `{log_dir}/zmx.log`. We store session-specific logs in `{log_dir}/{session_name}.log`. Right now they are enabled by default and cannot be disabled. The idea here is to help with initial development until we reach a stable state.
+
+The log directory is resolved in this order:
+
+1. `ZMX_DIR/logs` if `ZMX_DIR` is set
+2. `XDG_STATE_HOME/zmx/logs` if `XDG_STATE_HOME` is set
+3. `HOME/.local/state/zmx/logs`
+4. `TMPDIR/zmx-$UID` (or `/tmp/zmx-$UID`) as a last resort
 
 ## a note on configuration
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -476,7 +476,8 @@ const Cfg = struct {
 
     pub fn init(alloc: std.mem.Allocator) !Cfg {
         const socket_dir = try socketDir(alloc);
-        const log_dir = try std.fmt.allocPrint(alloc, "{s}/logs", .{socket_dir});
+        errdefer alloc.free(socket_dir);
+        const log_dir = try logDir(alloc);
         errdefer alloc.free(log_dir);
 
         const dir_mode = if (std.posix.getenv("ZMX_DIR_MODE")) |m|
@@ -511,9 +512,25 @@ const Cfg = struct {
             try std.fmt.allocPrint(alloc, "{s}/zmx", .{xdg_runtime})
         else
             try std.fmt.allocPrint(alloc, "{s}/zmx-{d}", .{ tmpdir, uid });
-        errdefer alloc.free(socket_dir);
 
         return socket_dir;
+    }
+
+    fn logDir(alloc: std.mem.Allocator) ![]const u8 {
+        const log_dir = if (posix.getenv("ZMX_DIR")) |zmxdir|
+            try std.fmt.allocPrint(alloc, "{s}/logs", .{zmxdir})
+        else if (posix.getenv("XDG_STATE_HOME")) |xdg_state_home|
+            try std.fmt.allocPrint(alloc, "{s}/zmx/logs", .{xdg_state_home})
+        else if (posix.getenv("HOME")) |home_dir|
+            try std.fmt.allocPrint(alloc, "{s}/.local/state/zmx/logs", .{home_dir})
+        else fallback: {
+            // This is the last resort: falling back to /tmp/$UID if HOME is unset.
+            const tmpdir = std.mem.trimRight(u8, posix.getenv("TMPDIR") orelse "/tmp", "/");
+            const uid = posix.getuid();
+            break :fallback try std.fmt.allocPrint(alloc, "{s}/zmx-{d}", .{ tmpdir, uid });
+        };
+
+        return log_dir;
     }
 
     pub fn deinit(self: *Cfg, alloc: std.mem.Allocator) void {
@@ -522,15 +539,24 @@ const Cfg = struct {
     }
 
     pub fn mkdir(self: *Cfg) !void {
-        posix.mkdirat(posix.AT.FDCWD, self.socket_dir, @intCast(self.dir_mode)) catch |err| switch (err) {
-            error.PathAlreadyExists => {},
-            else => return err,
-        };
+        try mkdirAll(self.socket_dir, @intCast(self.dir_mode));
+        try mkdirAll(self.log_dir, @intCast(self.dir_mode));
+    }
 
-        posix.mkdirat(posix.AT.FDCWD, self.log_dir, @intCast(self.dir_mode)) catch |err| switch (err) {
-            error.PathAlreadyExists => {},
-            else => return err,
-        };
+    fn mkdirAll(sub_dir_path: []const u8, mode: posix.mode_t) !void {
+        var it = try std.fs.path.componentIterator(sub_dir_path);
+        var component = it.last() orelse return error.BadPathName;
+        while (true) {
+            posix.mkdirat(posix.AT.FDCWD, component.path, mode) catch |err| switch (err) {
+                error.PathAlreadyExists => {},
+                error.FileNotFound => |e| {
+                    component = it.previous() orelse return e;
+                    continue;
+                },
+                else => |e| return e,
+            };
+            component = it.next() orelse return;
+        }
     }
 };
 


### PR DESCRIPTION
Fixes https://github.com/neurosnap/zmx/issues/28

As discussed in the linked issue, it's not typical for an application to keep its logs along the runtime files. This PR updates the code to place logs to `$XDG_STATE_HOME` when set (see the updated README for explanation of the fallback logic).