### PR TITLE
Resolve task bash from PATH

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -682,7 +682,7 @@ const Daemon = struct {
             std.posix.exit(1);
         }
 
-        const shell: [:0]const u8 = if (self.is_task_mode) "/bin/bash" else util.detectShell();
+        const shell: [:0]const u8 = if (self.is_task_mode) "bash" else util.detectShell();
         // Use "-shellname" as argv[0] to signal login shell (traditional method)
         const login_shell = try std.fmt.allocPrintSentinel(
             alloc,
@@ -691,8 +691,8 @@ const Daemon = struct {
             0,
         );
         const argv = [_:null]?[*:0]const u8{ login_shell, null };
-        const err = std.posix.execveZ(shell, &argv, std.c.environ);
-        std.log.err("execve failed: err={s}", .{@errorName(err)});
+        const err = std.posix.execvpeZ(shell, &argv, std.c.environ);
+        std.log.err("execvpe failed: shell={s} err={s}", .{ shell, @errorName(err) });
         std.posix.exit(1);
     }
 


### PR DESCRIPTION
Execute bash via PATH lookup instead of hardcoding /bin/bash. Current implementation is broken in NixOS.