### PR TITLE
fix(kill): release socket before grace sleep so `kill X; run X` works

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -847,15 +847,23 @@ const Daemon = struct {
                 };
 
                 defer {
-                    self.handleKill();
-                    self.deinit();
-                    posix.close(pty_fd);
-                    _ = posix.waitpid(self.pid, 0);
+                    // Close and unlink the listen socket BEFORE handleKill()'s
+                    // 500ms SIGHUP->SIGKILL grace sleep. Otherwise a `zmx run`
+                    // for the same name issued in that window connect()s into
+                    // the kernel backlog of a socket we'll never accept() on
+                    // again, then gets RST'd when we finally close it below --
+                    // the client sees ConnectionResetByPeer and exits 1 with
+                    // no session created. Releasing the name first lets the
+                    // next `run` bind a fresh socket immediately.
                     posix.close(server_sock_fd);
                     std.log.info("deleting socket file session={s}", .{self.session_name});
                     dir.deleteFile(self.session_name) catch |err| {
                         std.log.warn("failed to delete socket file err={s}", .{@errorName(err)});
                     };
+                    self.handleKill();
+                    self.deinit();
+                    posix.close(pty_fd);
+                    _ = posix.waitpid(self.pid, 0);
                 }
 
                 try daemonLoop(self, server_sock_fd, pty_fd);
@@ -1768,6 +1776,17 @@ fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
         error.BrokenPipe, error.ConnectionResetByPeer => return,
         else => return err,
     };
+
+    // Block until the daemon hangs up. The daemon's shutdown defer closes
+    // and unlinks the listen socket before it closes client connections,
+    // so by the time we read EOF here the session name is free for reuse
+    // and a subsequent `zmx run <name>` can't land in the dying daemon's
+    // accept backlog.
+    var drain: [256]u8 = undefined;
+    while (true) {
+        const n = posix.read(fd, &drain) catch break;
+        if (n == 0) break;
+    }
 
     var buf: [100]u8 = undefined;
     var w = std.fs.File.stdout().writer(&buf);

--- a/test/kill_run_race.bats
+++ b/test/kill_run_race.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+# Regression test for the `zmx kill X; zmx run X` race.
+#
+# Previously `zmx kill` returned immediately after sending the IPC .Kill,
+# while the daemon's shutdown defer ran handleKill() -- SIGHUP, 500ms sleep,
+# SIGKILL -- BEFORE closing/unlinking the listen socket. A `zmx run X`
+# issued in that window would connect() into the kernel backlog of a
+# socket the daemon would never accept() on again, then get RST'd
+# (ConnectionResetByPeer) when the daemon finally closed the listen fd,
+# exiting 1 with no output and no session created.
+
+load test_helper
+
+@test "kill then immediate run with same name succeeds" {
+  for i in 1 2 3; do
+    "$ZMX" run race-x -d echo first
+    wait_for_session race-x
+
+    "$ZMX" kill race-x
+
+    # Immediately reuse the same session name. Must not land in the
+    # dying daemon's listen backlog.
+    run "$ZMX" run race-x -d echo second
+    echo "iteration $i: status=$status output=$output"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"session \"race-x\" created"* ]]
+
+    # New session must be live and serving requests.
+    wait_for_session race-x
+    run "$ZMX" history race-x
+    [ "$status" -eq 0 ]
+
+    "$ZMX" kill race-x
+  done
+}


### PR DESCRIPTION
## The race

`zmx kill X` returns immediately after sending the IPC `.Kill`. The daemon then breaks out of `daemonLoop` and enters its shutdown `defer` block, which (before this PR) ran in this order:

1. `handleKill()` → `shutdown()`, SIGHUP, **`std.Thread.sleep(500ms)`**, SIGKILL
2. `deinit()`, close pty, `waitpid`
3. `posix.close(server_sock_fd)`
4. `dir.deleteFile(session_name)`

During the 500ms sleep in step 1, the listen socket is still bound and the kernel is still accepting connections into its backlog — but the daemon will never `accept()` again. A `zmx run X` issued in that window:

- sees the socket file → assumes the session exists
- `connect()` succeeds (kernel backlog)
- writes `.Run` (buffered in kernel, never read)
- daemon reaches step 3, closes the listen fd → kernel RSTs the un-accepted connection
- client's `tail()` gets `error.ConnectionResetByPeer` → `posix.exit(1)` with no output and no session

## Repro

```bash
ZMX_DIR=$(mktemp -d)
export ZMX_DIR
zmx run x -d echo hi
sleep 0.2
zmx kill x
zmx run x -d echo hi   # exits 1, prints nothing, no session created
echo "exit=$?"
zmx list --short       # empty
```

## Fix

**1. Reorder the shutdown `defer`** so the listen socket is closed and the socket file unlinked *before* `handleKill()`'s 500ms grace period. The session name is free for reuse the instant the daemon leaves its accept loop. (#113 touched this same defer for an unrelated macOS waitpid issue; the `handleKill` → `waitpid` ordering it established is preserved.)

**2. Make `zmx kill` synchronous**: after sending `.Kill`, drain-read the connection until EOF. The daemon now closes client fds (inside `handleKill` → `shutdown`) *after* unlinking the socket file, so when `kill` returns the name is guaranteed free. This avoids a client-side `deleteFile`, which would itself race with a fresh session created concurrently.

## Test

Adds `test/kill_run_race.bats`, which loops `run X` / `kill X` / `run X` three times and asserts the second `run` reports `session "X" created` and the new session serves `history`.

On `main`:
```
not ok 1 kill then immediate run with same name succeeds
# iteration 1: status=1 output=
```

With this PR:
```
ok 1 kill then immediate run with same name succeeds
```

Full `bats test/` (31 tests) and `zig build test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)