### PR TITLE
doc: Add emacs-term-sessions to list of community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ abduco provides session management (i.e. it allows programs to be run independen
 
 ## community tools
 
+- [emacs-term-sessions](https://github.com/ArthurHeymans/emacs-term-sessions) Persistent terminal sessions in Emacs, both local and remote.
 - [pi-zmx](https://github.com/deevus/pi-zmx) -- [pi](https://pi.dev) extension for zmx.
 - [zsm](https://github.com/mdsakalu/zmx-session-manager) -- TUI session manager for zmx. List, preview, filter, and kill sessions from an interactive terminal UI.
 - [zmosh](https://github.com/mmonad/zmosh) -- A fork of zmx that adds encrypted UDP auto-reconnect for remote sessions (like mosh).


### PR DESCRIPTION
I put this at the start of the list because this would be the somewhat
alphabetical.