### PR TITLE
fix: strip OSC 8 from terminal state tracking

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1161,8 +1161,14 @@ const Daemon = struct {
         std.log.debug("run command len={d}", .{payload.len});
     }
 
-    pub fn handleOutput(self: *Daemon, payload: []const u8, vt_stream: anytype) !void {
-        vt_stream.nextSlice(payload);
+    pub fn handleOutput(
+        self: *Daemon,
+        payload: []const u8,
+        vt_stream: anytype,
+        osc8_stripper: *util.Osc8Stripper,
+    ) !void {
+        const state_payload = try osc8_stripper.strip(self.alloc, payload);
+        vt_stream.nextSlice(state_payload);
         self.has_pty_output = true;
         for (self.clients.items) |client| {
             try ipc.appendMessage(self.alloc, &client.write_buf, .Output, payload);
@@ -2496,6 +2502,8 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
     defer term.deinit(daemon.alloc);
     var vt_stream = term.vtStream();
     defer vt_stream.deinit();
+    var osc8_stripper = util.Osc8Stripper{};
+    defer osc8_stripper.deinit(daemon.alloc);
 
     daemon_loop: while (daemon.running) {
         poll_fds.clearRetainingCapacity();
@@ -2581,8 +2589,8 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                     std.log.info("shell exited pty_fd={d}", .{pty_fd});
                     break :daemon_loop;
                 } else {
-                    // Feed PTY output to terminal emulator for state tracking
-                    vt_stream.nextSlice(buf[0..n]);
+                    const state_payload = try osc8_stripper.strip(daemon.alloc, buf[0..n]);
+                    vt_stream.nextSlice(state_payload);
                     daemon.has_pty_output = true;
 
                     // When no real terminal client has attached yet, respond to
@@ -2684,7 +2692,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                 while (client.read_buf.next()) |msg| {
                     switch (msg.header.tag) {
                         .Input => try daemon.handleInput(client, msg.payload),
-                        .Output => try daemon.handleOutput(msg.payload, &vt_stream),
+                        .Output => try daemon.handleOutput(msg.payload, &vt_stream, &osc8_stripper),
                         .Init => try daemon.handleInit(client, pty_fd, &term, msg.payload),
                         .Switch => try daemon.handleSwitch(msg.payload),
                         .Resize => try daemon.handleResize(client, pty_fd, &term, msg.payload),

--- a/src/util.zig
+++ b/src/util.zig
@@ -5,6 +5,95 @@ const ipc = @import("ipc.zig");
 const socket = @import("socket.zig");
 const testing = std.testing;
 
+pub const Osc8Stripper = struct {
+    state: State = .ground,
+    pending: std.ArrayList(u8) = .empty,
+    output: std.ArrayList(u8) = .empty,
+
+    const State = enum {
+        ground,
+        esc,
+        osc,
+        osc_8,
+        skip_osc_8,
+        skip_osc_8_esc,
+    };
+
+    pub fn deinit(self: *Osc8Stripper, alloc: std.mem.Allocator) void {
+        self.pending.deinit(alloc);
+        self.output.deinit(alloc);
+    }
+
+    pub fn strip(self: *Osc8Stripper, alloc: std.mem.Allocator, input: []const u8) ![]const u8 {
+        if (self.state == .ground and std.mem.indexOfScalar(u8, input, 0x1b) == null and
+            std.mem.indexOfScalar(u8, input, 0x9d) == null)
+        {
+            return input;
+        }
+
+        self.output.clearRetainingCapacity();
+        for (input) |byte| {
+            switch (self.state) {
+                .ground => switch (byte) {
+                    0x1b => {
+                        self.pending.clearRetainingCapacity();
+                        try self.pending.append(alloc, byte);
+                        self.state = .esc;
+                    },
+                    0x9d => {
+                        self.pending.clearRetainingCapacity();
+                        try self.pending.append(alloc, byte);
+                        self.state = .osc;
+                    },
+                    else => try self.output.append(alloc, byte),
+                },
+                .esc => {
+                    try self.pending.append(alloc, byte);
+                    if (byte == ']') {
+                        self.state = .osc;
+                    } else {
+                        try self.flushPending(alloc);
+                    }
+                },
+                .osc => {
+                    try self.pending.append(alloc, byte);
+                    if (byte == '8') {
+                        self.state = .osc_8;
+                    } else {
+                        try self.flushPending(alloc);
+                    }
+                },
+                .osc_8 => {
+                    try self.pending.append(alloc, byte);
+                    if (byte == ';') {
+                        self.pending.clearRetainingCapacity();
+                        self.state = .skip_osc_8;
+                    } else {
+                        try self.flushPending(alloc);
+                    }
+                },
+                .skip_osc_8 => switch (byte) {
+                    0x07, 0x9c => self.state = .ground,
+                    0x1b => self.state = .skip_osc_8_esc,
+                    else => {},
+                },
+                .skip_osc_8_esc => switch (byte) {
+                    '\\' => self.state = .ground,
+                    0x1b => {},
+                    else => self.state = .skip_osc_8,
+                },
+            }
+        }
+        return self.output.items;
+    }
+
+    fn flushPending(self: *Osc8Stripper, alloc: std.mem.Allocator) !void {
+        try self.output.appendSlice(alloc, self.pending.items);
+        self.pending.clearRetainingCapacity();
+        self.state = .ground;
+    }
+};
+
 pub const SessionEntry = struct {
     name: []const u8,
     pid: ?i32,
@@ -1029,6 +1118,33 @@ test "serializeTerminalState excludes synchronized output replay" {
     // but NOT synchronized output (DECSET 2026)
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?2004h") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?2026h") == null);
+}
+
+test "Osc8Stripper strips split hyperlinks" {
+    const chunks = [_][]const u8{
+        "\x1b]8;;file:///tmp/very-long-path\x1b\\hel",
+        "lo\x1b]8;;\x1b\\!",
+    };
+    try expectStripped(&chunks, "hello!");
+}
+
+test "Osc8Stripper preserves non-hyperlink escape sequences" {
+    const chunks = [_][]const u8{
+        "\x1b]0;title\x1b\\",
+        "\x1b[31mred\x1b[0m",
+    };
+    try expectStripped(&chunks, "\x1b]0;title\x1b\\\x1b[31mred\x1b[0m");
+}
+
+fn expectStripped(chunks: []const []const u8, expected: []const u8) !void {
+    var stripper = Osc8Stripper{};
+    defer stripper.deinit(testing.allocator);
+    var actual = std.ArrayList(u8).empty;
+    defer actual.deinit(testing.allocator);
+    for (chunks) |chunk| {
+        try actual.appendSlice(testing.allocator, try stripper.strip(testing.allocator, chunk));
+    }
+    try testing.expectEqualStrings(expected, actual.items);
 }
 
 fn testCreateTerminal(alloc: std.mem.Allocator, cols: u16, rows: u16, vt_data: []const u8) !ghostty_vt.Terminal {


### PR DESCRIPTION
I have this problem where for long runnign codex session inside zmx, zmx would becomes unresponsive, disappear. Ask an agent to try to reproduce the error and it's boiled down to

1. Codex prints lots of clickable file/link references using OSC 8 escape sequences.
2. Ghostty receives those bytes through zmx and renders them as links.
3. zmx also feeds the same bytes into its internal ghostty-vt terminal model so it can restore the pane when you reattach.
4. With many long, wrapped OSC 8 links, that internal model can hit hyperlink/capacity trouble and the zmx daemon stops responding to IPC.
5. Then zmx attach, zmx print, zmx history, zmx ls, etc. start timing out with session unresponsive: Timeout / daemon may be busy.

so this PR:

- Strip OSC 8 hyperlink control sequences before feeding bytes into the daemon's `ghostty-vt` state tracker.
- Keep the original output unchanged for attached clients.
- Add unit coverage for split OSC 8 hyperlinks and for preserving non-hyperlink escape sequences.

The fix seems a bit targeted, let me know if it's not something we want and `ghostty-vt` should be the place instead.

> **the part below this is written by an agent**

## Reproduction


Before this change, long wrapped OSC 8 labels can make a session unresponsive while the daemon tracks terminal state. This repro initializes an attached 82-column pane, injects wrapped OSC 8 labels, and stops as soon as the session reports timeout/error signals.

```bash
set -uo pipefail

zig build >/dev/null
ZMX="$PWD/zig-out/bin/zmx"
DIR=$(mktemp -d /tmp/zmx-osc8-repro.XXXXXX)
CLIENT_LOG="$DIR/client.log"
BUG_PATTERN='OutOfSpace|HyperlinkSetOutOfMemory|stale socket|session unresponsive|daemon may be busy'
PRINT_TIMEOUT=6

run_with_timeout() {
  perl -e 'my $timeout = shift @ARGV; my @cmd = @ARGV; my $pid = fork(); die "fork failed\n" unless defined $pid; if ($pid == 0) { exec @cmd; exit 127; } local $SIG{ALRM} = sub { kill "TERM", $pid; select undef, undef, undef, 0.2; kill "KILL", $pid; exit 124; }; alarm $timeout; waitpid($pid, 0); my $s = $?; exit(($s & 127) ? 128 + ($s & 127) : ($s >> 8));' "$@"
}

cleanup() {
  env ZMX_DIR="$DIR" ZMX_SESSION_PREFIX= ZMX_SESSION= "$ZMX" kill repro >/dev/null 2>&1 || true
}
trap cleanup EXIT

env ZMX_DIR="$DIR" ZMX_SESSION_PREFIX= ZMX_SESSION= "$ZMX" run repro -d sleep 3600 >/dev/null 2>>"$CLIENT_LOG"
/usr/bin/script -q /dev/null /bin/zsh -lc 'stty rows 568 cols 82; printf "\034" | env ZMX_DIR="'"$DIR"'" ZMX_SESSION_PREFIX= ZMX_SESSION= "'"$ZMX"'" attach repro' >/dev/null 2>>"$CLIENT_LOG" </dev/null

printf 'injecting: wrapped OSC 8 links\n'
PRINT_RC=0
FAILED_CHUNK=''
for chunk in {0..199}; do
  perl -e '$start = shift; for ($j = 0; $j < 8; $j++) { $i = $start + $j; $label = "very/long/path/that/wraps/in/a/narrow/pane/review-output-file.md:" . (4 + ($i % 17)); $url = "file:///tmp/example-workspace/" . $label . "?repro=" . $i; print "Where: \e]8;;$url\e\\$label #$i\e]8;;\e\\, \e]8;;https://example.test/repro/$i\e\\evidence-link-$i\e]8;;\e\\ repeated terminal evidence text to wrap active hyperlink labels in an 82 column pane\r\n"; }' $((chunk * 8)) |
    run_with_timeout "$PRINT_TIMEOUT" env ZMX_DIR="$DIR" ZMX_SESSION_PREFIX= ZMX_SESSION= "$ZMX" print repro >/dev/null 2>>"$CLIENT_LOG"
  PRINT_RC=$?
  if [ "$PRINT_RC" -ne 0 ]; then
    FAILED_CHUNK=$chunk
    break
  fi
  if rg -q "$BUG_PATTERN" "$DIR/logs" "$CLIENT_LOG" 2>/dev/null; then
    FAILED_CHUNK=$chunk
    break
  fi
done

SESSION=$(env ZMX_DIR="$DIR" ZMX_SESSION_PREFIX= ZMX_SESSION= "$ZMX" ls --short 2>>"$CLIENT_LOG" || true)
HISTORY_MATCHES=0
if printf '%s\n' "$SESSION" | rg -qx 'repro'; then
  HISTORY_MATCHES=$(env ZMX_DIR="$DIR" ZMX_SESSION_PREFIX= ZMX_SESSION= "$ZMX" history repro 2>>"$CLIENT_LOG" | rg -o 'review-output-file|evidence-link' | wc -l | tr -d ' ')
fi
BUG_MATCHES=$(rg -n "$BUG_PATTERN" "$DIR/logs" "$CLIENT_LOG" 2>/dev/null || true)
BUG_MATCH_COUNT=$(printf '%s\n' "$BUG_MATCHES" | sed '/^$/d' | wc -l | tr -d ' ')
FIRST_SIGNAL=$(printf '%s\n' "$BUG_MATCHES" | sed '/^$/d' | head -1)

if printf '%s\n' "$SESSION" | rg -qx 'repro' && [ "$PRINT_RC" = "0" ] && [ "$BUG_MATCH_COUNT" = "0" ]; then
  printf 'RESULT: PASS_FIXED\n'
  printf 'session: alive\n'
  printf 'history_matches: %s\n' "$HISTORY_MATCHES"
  printf 'bug_log_matches: 0\n'
else
  printf 'RESULT: BUG_REPRODUCED\n'
  if [ -n "$FAILED_CHUNK" ]; then
    printf 'stopped_at_chunk: %s\n' "$FAILED_CHUNK"
  fi
  if [ "$PRINT_RC" -ne 0 ]; then
    printf 'print_rc: %s\n' "$PRINT_RC"
  fi
  if printf '%s\n' "$SESSION" | rg -qx 'repro'; then
    printf 'session: alive or partially responsive\n'
  else
    printf 'session: missing or unresponsive\n'
  fi
  printf 'history_matches: %s\n' "$HISTORY_MATCHES"
  printf 'bug_log_matches: %s\n' "$BUG_MATCH_COUNT"
  if [ -n "$FIRST_SIGNAL" ]; then
    printf 'first_signal: %s\n' "$FIRST_SIGNAL"
  fi
fi
printf 'repro_dir: %s\n' "$DIR"
```

On current `main`, this produces:

```text
injecting: wrapped OSC 8 links
RESULT: BUG_REPRODUCED
stopped_at_chunk: 1
session: missing or unresponsive
history_matches: 0
bug_log_matches: 1
first_signal: /tmp/zmx-osc8-repro.XXXXXX/logs/zmx.log:7:[...] [error] (default): session unresponsive: Timeout
repro_dir: /tmp/zmx-osc8-repro.XXXXXX
```

With this change, it produces:

```text
injecting: wrapped OSC 8 links
RESULT: PASS_FIXED
session: alive
history_matches: 1988
bug_log_matches: 0
repro_dir: /tmp/zmx-osc8-repro.XXXXXX
```

