### PR TITLE
fix(docs): correct zmx-select field parsing in session picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,10 @@ Requires [fzf](https://github.com/junegunn/fzf).
 zmx-select() {
   local display
   display=$(zmx list 2>/dev/null | while IFS=$'\t' read -r name pid clients created dir; do
-    name=${name#session_name=}
-    pid=${pid#pid=}
-    clients=${clients#clients=}
-    dir=${dir#started_in=}
+    name=${name#*name=}
+    pid=${pid#*pid=}
+    clients=${clients#*clients=}
+    dir=${dir#*start_dir=}
     printf "%-20s  pid:%-8s  clients:%-2s  %s\n" "$name" "$pid" "$clients" "$dir"
   done)
 


### PR DESCRIPTION
The zmx-select snippet stripped field prefixes (session_name=, started_in=) that don't match the actual `zmx list` output, so the session name displayed as "name=test" instead of "test" and attach failed. Use glob strips (#*name=, #*start_dir=) which match the real prefixes and also swallow the leading "→ "/"  " current-session marker.

Fixes #153