### PR TITLE
fix: forward real terminal pixel size instead of hardcoding 0x0

### DIFF
--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -38,12 +38,14 @@ pub const Header = packed struct {
 pub const Resize = packed struct {
     rows: u16,
     cols: u16,
+    xpixel: u16 = 0,
+    ypixel: u16 = 0,
 };
 
 pub fn getTerminalSize(fd: i32) Resize {
     var ws: cross.c.struct_winsize = undefined;
     if (cross.c.ioctl(fd, cross.c.TIOCGWINSZ, &ws) == 0 and ws.ws_row > 0 and ws.ws_col > 0) {
-        return .{ .rows = ws.ws_row, .cols = ws.ws_col };
+        return .{ .rows = ws.ws_row, .cols = ws.ws_col, .xpixel = ws.ws_xpixel, .ypixel = ws.ws_ypixel };
     }
     return .{ .rows = 24, .cols = 160 };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -702,8 +702,8 @@ const Daemon = struct {
         var ws: cross.c.struct_winsize = .{
             .ws_row = size.rows,
             .ws_col = size.cols,
-            .ws_xpixel = 0,
-            .ws_ypixel = 0,
+            .ws_xpixel = size.xpixel,
+            .ws_ypixel = size.ypixel,
         };
 
         var master_fd: c_int = undefined;
@@ -978,8 +978,8 @@ const Daemon = struct {
             var ws: cross.c.struct_winsize = .{
                 .ws_row = resize.rows,
                 .ws_col = resize.cols,
-                .ws_xpixel = 0,
-                .ws_ypixel = 0,
+                .ws_xpixel = resize.xpixel,
+                .ws_ypixel = resize.ypixel,
             };
             _ = cross.c.ioctl(pty_fd, cross.c.TIOCSWINSZ, &ws);
             // Disable prompt_redraw before resize. The daemon's internal terminal
@@ -1017,8 +1017,8 @@ const Daemon = struct {
         var ws: cross.c.struct_winsize = .{
             .ws_row = resize.rows,
             .ws_col = resize.cols,
-            .ws_xpixel = 0,
-            .ws_ypixel = 0,
+            .ws_xpixel = resize.xpixel,
+            .ws_ypixel = resize.ypixel,
         };
         _ = cross.c.ioctl(pty_fd, cross.c.TIOCSWINSZ, &ws);
         // Disable prompt_redraw before resize (same rationale as handleInit).


### PR DESCRIPTION
## Summary

`ipc.Resize` only carries `rows`/`cols`, and `getTerminalSize()` drops the `ws_xpixel`/`ws_ypixel` fields that `ioctl(TIOCGWINSZ)` already returns. As a result, all three `TIOCSWINSZ` call sites in the daemon (`spawnPty`, `handleInit`, `handleResize`) hardcode the inner pty's pixel dimensions to `0x0`, regardless of what the outer terminal actually reports.

This breaks Kitty/Ghostty graphics-protocol image rendering for anything running inside a zmx session: image size in pixels is computed from a pixel-per-cell ratio, and that ratio is always `0/cell` since the pty thinks the terminal is `0x0` pixels. For example, nvim + `snacks.nvim` image rendering shows `:checkhealth snacks` → `Terminal Dimensions: {cell}: 0 x 0 pixels`, and images get scaled to nothing before being sent to the terminal — the placeholder cell space is reserved correctly (that part is row/col based), but no image ever shows up.

This looks related to #14, though that issue's root cause turned out to be more about `ghostty-vt`'s `TerminalFormatter` not snapshotting/restoring kitty image escape codes across reattach. This PR is a narrower, independent fix: it just stops discarding the real pixel dimensions that were already available via `TIOCGWINSZ`/`TIOCSWINSZ`.

## Changes

- `ipc.Resize`: add `xpixel`/`ypixel` fields (default `0` to stay wire-compatible with older clients/daemons during upgrade).
- `ipc.getTerminalSize()`: populate the new fields from the real `ioctl(TIOCGWINSZ)` result instead of dropping them.
- `main.zig`: thread `xpixel`/`ypixel` through to the three `TIOCSWINSZ` call sites instead of hardcoding `0`.

## Test plan

- [x] `zig build` succeeds (aarch64-macos)
- [x] `zig build test` passes
- [ ] Manually verified end-to-end with a Kitty-graphics-protocol consumer (e.g. `snacks.nvim` image rendering) inside a zmx session — would appreciate someone with the right terminal/setup confirming, since I built and unit-tested this but the maintainer's review/CI environment may be a better fit for full e2e verification.