### PR TITLE
doc: add alternative gentle-hint pattern for server SSH workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,25 @@ if command -v zmx &> /dev/null && command -v fzf &> /dev/null && [[ -z "$ZMX_SES
 fi
 ```
 
+#### Alternative: gentle hint (server use)
+
+If you use zmx on a shared server and SSH in frequently for quick operations,
+auto-launching the picker on every connection may be too aggressive. Instead,
+show a one-line reminder when active sessions exist:
+
+```bash
+if command -v zmx &> /dev/null && [[ -z "$ZMX_SESSION" ]]; then
+  local count
+  count=$(zmx ls --short 2>/dev/null | wc -l)
+  if [[ "$count" -gt 0 ]]; then
+    echo "zmx: $count session(s) active — \`zmx-select\` to attach" >&2
+  fi
+fi
+```
+
+Choose the auto-launch pattern for dedicated dev machines, and the hint
+pattern for shared servers where you frequently run quick commands.
+
 </details>
 
 ## session prefix


### PR DESCRIPTION
## Summary

The current session-picker docs only show an auto-launch pattern (`zmx-select && exit`), which forces the interactive picker on every SSH login. This is inconvenient on shared or dev servers where you frequently SSH in to run quick commands and dont want to be prompted every time.

## What this adds

A new **Alternative: gentle hint (server use)** subsection inside the session-picker docs, with a shell snippet that:

- Checks for active zmx sessions on SSH login
- Shows a one-line hint: `zmx: N session(s) active — zmx-select to attach`
- Does NOT block the shell or launch the picker
- Lets the user decide whether to call `zmx-select` manually

## Why separate from the auto-launch pattern

The two patterns serve different use cases:

| Pattern | Best for |
|---|---|
| Auto-launch (`zmx-select && exit`) | Dedicated dev machines, single-purpose SSH |
| Gentle hint (this PR) | Shared servers, frequent quick commands |

Users can pick whichever fits their workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)