### PR TITLE
Add session labels (get/set/unset/clear) and list --where filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Use spec: https://common-changelog.org/
 
 ## Staged
 
+### Added
+
+- `zmx set <name> k=v ...` to attach key=value labels to live sessions
+- `zmx get <name>` to read labels from a session
+- `zmx set <name> key=` to remove a specific label (empty value = delete)
+- `zmx clear <name>` to remove all labels
+- `zmx list` now shows labels by default as tab-separated fields
+- `zmx list --where key=value` to filter sessions by exact match
+- `zmx list --where key=value*` to filter sessions by prefix match
+- Built-in fields `name`, `start_dir`, `cmd` are queryable via `--where` without setting labels
+- Built-in keys (`name`, `start_dir`, `cmd`) are read-only and rejected by `zmx set`
+- Shell completions for `get`, `set`, `clear` commands (bash, zsh, fish, nu)
+
+
 ### Fixed
 
 - `zmx run` will now detect heredocs and add the completion marker to a newline

--- a/README.md
+++ b/README.md
@@ -328,6 +328,25 @@ zmx k tests  # kills d.tests
 zmx wait     # suspends until all tasks prefixed with "d." are complete
 ```
 
+## label inheritance
+
+When creating a new session from inside an existing one (`$ZMX_SESSION` is set), labels are automatically inherited from the parent session. This means if you set `project=zmx` on a session, any child sessions created from within it will also have `project=zmx`.
+
+To control which labels are inherited, set `ZMX_INHERIT_LABELS`:
+
+```bash
+# Inherit all labels (default)
+zmx a child
+
+# Inherit no labels
+export ZMX_INHERIT_LABELS=
+zmx a child
+
+# Inherit only specific labels
+export ZMX_INHERIT_LABELS=project,team
+zmx a child
+```
+
 ## philosophy
 
 The entire argument for `zmx` instead of something like `tmux` that has windows, panes, splits, etc. is that job should be handled by your os window manager. By using something like `tmux` you now have redundant functionality in your dev stack: a window manager for your os and a window manager for your terminal. Further, in order to use modern terminal features, your terminal emulator **and** `tmux` need to have support for them. This holds back the terminal enthusiast community and feature development.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,11 @@ Commands:
   [p]rint <name> <text...>                 Inject text into session display
   [wr]ite <name> <file_path>               Write stdin to file_path through the session
   [d]etach                                 Detach all clients (ctrl+\\ for current client)
-  [l]ist|ls [--short]                      List active sessions
+  [l]ist|ls [--short|--where k=v]           List active sessions
+  [g]et <name>                              Get session labels
+  set|z <name> k=v ...                       Set session labels
+  [un]set <name> key ...                    Remove session labels
+  [cl]ear <name>                            Clear all session labels
   [k]ill <name>... [--force]               Kill session and all attached clients
   [hi]story <name> [--vt|--html]           Output session scrollback
   [w]ait <name>...                         Wait for session tasks to complete
@@ -92,6 +96,44 @@ Commands:
   [v]ersion                                Show version and metadata (socket dir, log dir)
   [h]elp                                   Show this help
 ```
+
+## session labels
+
+Attach key=value labels to live sessions for discovery and filtering.
+
+```bash
+# Set labels
+zmx set mysession project=zmx env=dev
+
+# Read labels
+zmx get mysession
+
+# Remove a label
+zmx unset mysession env
+
+# Inside a session, "." resolves to current session
+zmx set . status=busy
+```
+
+Labels are shown by default in `zmx list` output. Use `--where` to filter:
+
+```bash
+# Exact match on a label
+zmx list --where project=zmx
+
+# Prefix match (trailing * wildcard)
+zmx list --where start_dir=/Users/max/code*
+
+# Combine filters (AND logic)
+zmx list --where project=zmx --where env=dev
+
+# Just session names, for scripting
+zmx list --short --where project=zmx
+```
+
+Built-in fields `name`, `start_dir`, and `cmd` are queryable via `--where` without setting any labels.
+
+Labels are in-memory and scoped to the session lifetime — they are not persisted after the session dies.
 
 ## shell prompt
 

--- a/build.zig
+++ b/build.zig
@@ -37,6 +37,7 @@ pub fn build(b: *std.Build) void {
         // on PATH" (true even via the CLT stub), which pulls in the iOS SDK at
         // configure time and breaks builds without full Xcode.
         .@"emit-xcframework" = false,
+        .@"emit-macos-app" = false,
     });
     exe_mod.addImport(
         "ghostty-vt",
@@ -73,6 +74,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .@"emit-lib-vt" = true,
             .@"emit-xcframework" = false,
+            .@"emit-macos-app" = false,
         });
         test_module.addImport(
             "ghostty-vt",
@@ -126,6 +128,7 @@ pub fn build(b: *std.Build) void {
                 .optimize = .ReleaseSafe,
                 .@"emit-lib-vt" = true,
                 .@"emit-xcframework" = false,
+                .@"emit-macos-app" = false,
             })) |release_dep| {
                 release_mod.addImport("ghostty-vt", release_dep.module("ghostty-vt"));
             }

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -32,7 +32,7 @@ const bash_completions =
     \\  cur="${COMP_WORDS[COMP_CWORD]}"
     \\  prev="${COMP_WORDS[COMP_CWORD-1]}"
     \\
-    \\  local commands="attach run send detach list completions kill history get set unset clear version help"
+    \\  local commands="attach run send detach list completions kill history get set clear version help"
     \\
     \\  if [[ $COMP_CWORD -eq 1 ]]; then
     \\    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -40,7 +40,7 @@ const bash_completions =
     \\  fi
     \\
     \\  case "$prev" in
-    \\    attach|run|send|kill|history|get|set|unset|clear)
+    \\    attach|run|send|kill|history|get|set|clear)
     \\      local sessions=$(zmx list --short 2>/dev/null | tr '\n' ' ')
     \\      COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
     \\      ;;
@@ -84,7 +84,6 @@ const zsh_completions =
     \\        'history:Output session scrollback'
     \\        'get:Get session labels'
     \\        'set:Set session labels'
-    \\        'unset:Remove session labels'
     \\        'clear:Clear all session labels'
     \\        'version:Show version'
     \\        'help:Show help message'
@@ -93,7 +92,7 @@ const zsh_completions =
     \\      ;;
     \\    args)
     \\      case $words[2] in
-    \\        attach|a|kill|k|run|r|send|s|history|hi|get|g|set|se|unset|un|clear|cl)
+    \\        attach|a|kill|k|run|r|send|s|history|hi|get|g|set|se|clear|cl)
     \\          _zmx_sessions
     \\          ;;
     \\        completions|c)
@@ -146,12 +145,11 @@ const fish_completions =
     \\complete -c zmx -n "__fish_is_nth_token 1" -a version -d 'Show version'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a get -d 'Get session labels'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a set -d 'Set session labels'
-    \\complete -c zmx -n "__fish_is_nth_token 1" -a unset -d 'Remove session labels'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a clear -d 'Clear all session labels'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a help -d 'Show help message'
     \\
     \\# Complete session names and shells
-    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run s send wr write hi history g get se set un unset cl clear" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
+    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run s send wr write hi history g get se set cl clear" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\complete -c zmx -n "not __fish_is_nth_token 1; and __fish_seen_subcommand_from k kill w wait t tail" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\
     \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from c completions" -a 'bash zsh fish' -d Shell
@@ -211,11 +209,6 @@ const nu_completions =
     \\export extern "zmx set" [
     \\    name?: string@"nu-complete zmx sessions"
     \\    ...pairs: string
-    \\]
-    \\
-    \\export extern "zmx unset" [
-    \\    name?: string@"nu-complete zmx sessions"
-    \\    ...keys: string
     \\]
     \\
     \\export extern "zmx clear" [

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -32,7 +32,7 @@ const bash_completions =
     \\  cur="${COMP_WORDS[COMP_CWORD]}"
     \\  prev="${COMP_WORDS[COMP_CWORD-1]}"
     \\
-    \\  local commands="attach run send detach list completions kill history version help"
+    \\  local commands="attach run send detach list completions kill history get set unset clear version help"
     \\
     \\  if [[ $COMP_CWORD -eq 1 ]]; then
     \\    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -40,7 +40,7 @@ const bash_completions =
     \\  fi
     \\
     \\  case "$prev" in
-    \\    attach|run|send|kill|history)
+    \\    attach|run|send|kill|history|get|set|unset|clear)
     \\      local sessions=$(zmx list --short 2>/dev/null | tr '\n' ' ')
     \\      COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
     \\      ;;
@@ -48,7 +48,7 @@ const bash_completions =
     \\      COMPREPLY=($(compgen -W "bash zsh fish" -- "$cur"))
     \\      ;;
     \\    list)
-    \\      COMPREPLY=($(compgen -W "--short" -- "$cur"))
+    \\      COMPREPLY=($(compgen -W "--short --where" -- "$cur"))
     \\      ;;
     \\    *)
     \\      ;;
@@ -82,6 +82,10 @@ const zsh_completions =
     \\        'completions:Shell completion scripts'
     \\        'kill:Kill a session'
     \\        'history:Output session scrollback'
+    \\        'get:Get session labels'
+    \\        'set:Set session labels'
+    \\        'unset:Remove session labels'
+    \\        'clear:Clear all session labels'
     \\        'version:Show version'
     \\        'help:Show help message'
     \\      )
@@ -89,14 +93,14 @@ const zsh_completions =
     \\      ;;
     \\    args)
     \\      case $words[2] in
-    \\        attach|a|kill|k|run|r|send|s|history|hi)
+    \\        attach|a|kill|k|run|r|send|s|history|hi|get|g|set|se|unset|un|clear|cl)
     \\          _zmx_sessions
     \\          ;;
     \\        completions|c)
     \\          _values 'shell' 'bash' 'zsh' 'fish'
     \\          ;;
     \\        list|l)
-    \\          _values 'options' '--short'
+    \\          _values 'options' '--short' '--where'
     \\          ;;
     \\      esac
     \\      ;;
@@ -140,10 +144,14 @@ const fish_completions =
     \\complete -c zmx -n "__fish_is_nth_token 1" -a tail -d 'Follow session output'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a completions -d 'Shell completions (bash, zsh, fish)'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a version -d 'Show version'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a get -d 'Get session labels'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a set -d 'Set session labels'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a unset -d 'Remove session labels'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a clear -d 'Clear all session labels'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a help -d 'Show help message'
     \\
     \\# Complete session names and shells
-    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run s send wr write hi history" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
+    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run s send wr write hi history g get se set un unset cl clear" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\complete -c zmx -n "not __fish_is_nth_token 1; and __fish_seen_subcommand_from k kill w wait t tail" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\
     \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from c completions" -a 'bash zsh fish' -d Shell
@@ -152,6 +160,7 @@ const fish_completions =
     \\complete -c zmx -n "__fish_seen_subcommand_from r run" -s d -d 'Detach from the calling terminal; use `wait` to track its status'
     \\complete -c zmx -n "__fish_seen_subcommand_from r run" -l fish -d 'Required when the session runs fish shell'
     \\complete -c zmx -n "__fish_seen_subcommand_from l list" -l short -d 'Short output'
+    \\complete -c zmx -n "__fish_seen_subcommand_from l list" -l where -d 'Filter by label (key=value)' -r
     \\complete -c zmx -n "__fish_seen_subcommand_from k kill" -l force -d 'Force kill'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l vt -d 'History format for escape sequences'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l html -d 'History format for escape sequences'
@@ -189,11 +198,29 @@ const nu_completions =
     \\]
     \\
     \\export extern "zmx detach" []
-    \\export extern "zmx list" [--short]
+    \\export extern "zmx list" [--short, --where: string]
     \\export extern "zmx history" [name: string@"nu-complete zmx sessions", --vt, --html]
     \\export extern "zmx wait" [...sessions: string@"nu-complete zmx sessions"]
     \\export extern "zmx tail" [...sessions: string@"nu-complete zmx sessions"]
     \\export extern "zmx version" []
     \\export extern "completions" [shell: string@"nu-complete zmx complete"]
+    \\export extern "zmx get" [
+    \\    name?: string@"nu-complete zmx sessions"
+    \\]
+    \\
+    \\export extern "zmx set" [
+    \\    name?: string@"nu-complete zmx sessions"
+    \\    ...pairs: string
+    \\]
+    \\
+    \\export extern "zmx unset" [
+    \\    name?: string@"nu-complete zmx sessions"
+    \\    ...keys: string
+    \\]
+    \\
+    \\export extern "zmx clear" [
+    \\    name?: string@"nu-complete zmx sessions"
+    \\]
+    \\
     \\export extern "zmx help" []
 ;

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -18,6 +18,11 @@ pub const Tag = enum(u8) {
     Switch = 11,
     Write = 12,
     TaskComplete = 13,
+    LabelGet = 14,
+    LabelSet = 15,
+    LabelUnset = 16,
+    LabelClear = 17,
+    LabelData = 18,
     // Non-exhaustive: this enum comes off the wire via bytesToValue and
     // @enumFromInt, so out-of-range values (14-255) are representable
     // rather than UB. Switches must handle `_` (unknown tag).
@@ -249,6 +254,71 @@ pub fn probeSession(
     return error.Unexpected;
 }
 
+const ProbeWithLabelsResult = struct {
+    fd: i32,
+    info: Info,
+    labels: ?[]const u8,
+};
+
+/// Send Info and optionally LabelGet in a single batch, then read all
+/// responses in one poll. Old daemons that don't understand LabelGet
+/// silently ignore it, so no extra timeout is incurred.
+pub fn probeSessionWithLabels(
+    alloc: std.mem.Allocator,
+    socket_path: []const u8,
+    fetch_labels: bool,
+) SessionProbeError!ProbeWithLabelsResult {
+    const timeout_ms = 1000;
+    const fd = try connectSession(socket_path);
+    errdefer posix.close(fd);
+
+    // Send both requests in one batch — daemon processes them in order.
+    send(fd, .Info, "") catch return error.Unexpected;
+    if (fetch_labels) {
+        send(fd, .LabelGet, "") catch {};
+    }
+
+    var poll_fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
+    const poll_result = posix.poll(&poll_fds, timeout_ms) catch return error.Unexpected;
+    if (poll_result == 0) return error.Timeout;
+
+    var sb = SocketBuffer.init(alloc) catch return error.Unexpected;
+    defer sb.deinit();
+
+    var info_result: ?Info = null;
+    var labels: ?[]const u8 = null;
+    errdefer if (labels) |l| alloc.free(l);
+
+    // Read all available data — both Info and LabelData responses
+    // may arrive in the same read.
+    while (true) {
+        const n = sb.read(fd) catch break;
+        if (n == 0) break;
+
+        while (sb.next()) |msg| {
+            if (msg.header.tag == .Info) {
+                if (msg.payload.len == @sizeOf(Info)) {
+                    info_result = std.mem.bytesToValue(Info, msg.payload[0..@sizeOf(Info)]);
+                }
+            } else if (msg.header.tag == .LabelData) {
+                labels = alloc.dupe(u8, msg.payload) catch null;
+            }
+        }
+
+        // If we have Info and either got labels or didn't ask, we're done.
+        if (info_result != null and (!fetch_labels or labels != null)) break;
+
+        // Poll briefly for more data (LabelData might come in a second packet).
+        const more = posix.poll(&poll_fds, 50) catch break;
+        if (more == 0) break;
+    }
+
+    if (info_result) |info| {
+        return .{ .fd = fd, .info = info, .labels = labels };
+    }
+    return error.Unexpected;
+}
+
 //  WIRE PROTOCOL FREEZE — read before "fixing" any test below.
 //
 //  Changing these constants does not fix the test; it breaks every
@@ -268,8 +338,41 @@ test "Tag wire values are frozen" {
         .{ Tag.Detach, 3 }, .{ Tag.DetachAll, 4 },     .{ Tag.Kill, 5 },
         .{ Tag.Info, 6 },   .{ Tag.Init, 7 },          .{ Tag.History, 8 },
         .{ Tag.Run, 9 },    .{ Tag.Ack, 10 },          .{ Tag.Switch, 11 },
-        .{ Tag.Write, 12 }, .{ Tag.TaskComplete, 13 },
+        .{ Tag.Write, 12 }, .{ Tag.TaskComplete, 13 }, .{ Tag.LabelGet, 14 },
+        .{ Tag.LabelSet, 15 }, .{ Tag.LabelUnset, 16 }, .{ Tag.LabelClear, 17 },
+        .{ Tag.LabelData, 18 },
     }) |p| try std.testing.expectEqual(@as(u8, p[1]), @intFromEnum(p[0]));
+}
+
+pub fn roundTripForTag(
+    alloc: std.mem.Allocator,
+    socket_path: []const u8,
+    request_tag: Tag,
+    payload: []const u8,
+    expected_tag: Tag,
+) SessionProbeError![]u8 {
+    const timeout_ms = 1000;
+    const fd = try connectSession(socket_path);
+    defer posix.close(fd);
+
+    send(fd, request_tag, payload) catch return error.Unexpected;
+
+    var poll_fds = [_]posix.pollfd{.{ .fd = fd, .events = posix.POLL.IN, .revents = 0 }};
+    const poll_result = posix.poll(&poll_fds, timeout_ms) catch return error.Unexpected;
+    if (poll_result == 0) return error.Timeout;
+
+    var sb = SocketBuffer.init(alloc) catch return error.Unexpected;
+    defer sb.deinit();
+
+    const n = sb.read(fd) catch return error.Unexpected;
+    if (n == 0) return error.Unexpected;
+
+    while (sb.next()) |msg| {
+        if (msg.header.tag == expected_tag) {
+            return alloc.dupe(u8, msg.payload) catch return error.Unexpected;
+        }
+    }
+    return error.Unexpected;
 }
 
 test "zeroed Info has no stack garbage in wire bytes" {

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -20,9 +20,8 @@ pub const Tag = enum(u8) {
     TaskComplete = 13,
     LabelGet = 14,
     LabelSet = 15,
-    LabelUnset = 16,
-    LabelClear = 17,
-    LabelData = 18,
+    LabelClear = 16,
+    LabelData = 17,
     // Non-exhaustive: this enum comes off the wire via bytesToValue and
     // @enumFromInt, so out-of-range values (14-255) are representable
     // rather than UB. Switches must handle `_` (unknown tag).
@@ -339,8 +338,8 @@ test "Tag wire values are frozen" {
         .{ Tag.Info, 6 },   .{ Tag.Init, 7 },          .{ Tag.History, 8 },
         .{ Tag.Run, 9 },    .{ Tag.Ack, 10 },          .{ Tag.Switch, 11 },
         .{ Tag.Write, 12 }, .{ Tag.TaskComplete, 13 }, .{ Tag.LabelGet, 14 },
-        .{ Tag.LabelSet, 15 }, .{ Tag.LabelUnset, 16 }, .{ Tag.LabelClear, 17 },
-        .{ Tag.LabelData, 18 },
+        .{ Tag.LabelSet, 15 }, .{ Tag.LabelClear, 16 },
+        .{ Tag.LabelData, 17 },
     }) |p| try std.testing.expectEqual(@as(u8, p[1]), @intFromEnum(p[0]));
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,97 @@ const SessionMatch = struct {
     }
 };
 
+const LabelKeyValue = struct {
+    key: []const u8,
+    value: []const u8,
+};
+
+const WhereFilter = struct {
+    key: []const u8,
+    value: []const u8,
+    is_prefix: bool,
+};
+
+fn resolveSessionOrEnv(alloc: std.mem.Allocator, session_name: ?[]const u8) ![]const u8 {
+    const sesh_env = socket.getSeshNameFromEnv();
+    const raw = if (session_name) |name|
+        if (std.mem.eql(u8, name, ".")) blk: {
+            if (sesh_env.len > 0) break :blk sesh_env;
+            var buf: [4096]u8 = undefined;
+            var w = std.fs.File.stderr().writer(&buf);
+            w.interface.print("error: \".\" requires ZMX_SESSION (are you inside a zmx session?)\n", .{}) catch {};
+            w.interface.flush() catch {};
+            return error.SessionNameRequired;
+        } else
+            name
+    else if (sesh_env.len > 0)
+        sesh_env
+    else {
+        var buf: [4096]u8 = undefined;
+        var w = std.fs.File.stderr().writer(&buf);
+        w.interface.print("error: session name required\n", .{}) catch {};
+        w.interface.flush() catch {};
+        return error.SessionNameRequired;
+    };
+    return socket.getSeshName(alloc, raw);
+}
+
+fn parseLabelSetArgs(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !struct {
+    session_name: ?[]const u8,
+    pairs: std.ArrayList(LabelKeyValue),
+} {
+    var session_name: ?[]const u8 = null;
+    var pairs: std.ArrayList(LabelKeyValue) = .empty;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) return error.InvalidArgument;
+        if (std.mem.indexOfScalar(u8, arg, '=')) |idx| {
+            try pairs.append(alloc, .{ .key = arg[0..idx], .value = arg[idx + 1 ..] });
+        } else if (session_name == null) {
+            session_name = arg;
+        } else {
+            return error.InvalidArgument;
+        }
+    }
+    return .{ .session_name = session_name, .pairs = pairs };
+}
+
+fn parseLabelKeyArgs(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !struct {
+    session_name: ?[]const u8,
+    keys: std.ArrayList([]const u8),
+} {
+    var session_name: ?[]const u8 = null;
+    var keys: std.ArrayList([]const u8) = .empty;
+    while (args.next()) |arg| {
+        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) return error.InvalidArgument;
+        if (session_name == null and std.mem.indexOfScalar(u8, arg, '=' ) == null and keys.items.len == 0) {
+            session_name = arg;
+        } else {
+            try keys.append(alloc, arg);
+        }
+    }
+    return .{ .session_name = session_name, .keys = keys };
+}
+
+fn serializeLabelSet(alloc: std.mem.Allocator, pairs: []const LabelKeyValue) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    for (pairs) |pair| {
+        try out.appendSlice(alloc, pair.key);
+        try out.append(alloc, '=');
+        try out.appendSlice(alloc, pair.value);
+        try out.append(alloc, '\n');
+    }
+    return out.toOwnedSlice(alloc);
+}
+
+fn serializeLabelKeys(alloc: std.mem.Allocator, keys: []const []const u8) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    for (keys) |key| {
+        try out.appendSlice(alloc, key);
+        try out.append(alloc, '\n');
+    }
+    return out.toOwnedSlice(alloc);
+}
+
 fn parseSessionArg(alloc: std.mem.Allocator, raw: []const u8) !SessionMatch {
     if (raw.len > 0 and raw[raw.len - 1] == '*') {
         const name = try socket.getSeshName(alloc, raw[0 .. raw.len - 1]);
@@ -90,7 +181,7 @@ pub fn main() !void {
     defer log_system.deinit();
 
     const cmd = args.next() orelse {
-        return list(&cfg, false);
+        return list(&cfg, false, &.{});
     };
 
     if (std.mem.eql(u8, cmd, "version") or std.mem.eql(u8, cmd, "v") or std.mem.eql(u8, cmd, "-v") or std.mem.eql(u8, cmd, "--version")) {
@@ -99,13 +190,52 @@ pub fn main() !void {
         return help();
     } else if (std.mem.eql(u8, cmd, "list") or std.mem.eql(u8, cmd, "l") or std.mem.eql(u8, cmd, "ls")) {
         var short = false;
-        if (args.next()) |arg| {
+        var where_filters = std.ArrayList(WhereFilter).empty;
+        defer where_filters.deinit(alloc);
+        while (args.next()) |arg| {
             if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
                 return help();
+            } else if (std.mem.eql(u8, arg, "--short")) {
+                short = true;
+            } else if (std.mem.startsWith(u8, arg, "--where")) {
+                // handle --where key=value or --where=key=value
+                const rest = if (arg.len > 7 and arg[7] == '=')
+                    arg[8..]
+                else
+                    args.next() orelse return help();
+                if (parseWhereExpr(rest)) |filter| {
+                    try where_filters.append(alloc, filter);
+                } else {
+                    return help();
+                }
             }
-            short = std.mem.eql(u8, arg, "--short");
         }
-        return list(&cfg, short);
+        return list(&cfg, short, where_filters.items);
+    } else if (std.mem.eql(u8, cmd, "get") or std.mem.eql(u8, cmd, "g")) {
+        var parsed = parseLabelKeyArgs(alloc, &args) catch return help();
+        defer parsed.keys.deinit(alloc);
+        const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
+        defer alloc.free(sesh);
+        return labelGet(&cfg, sesh);
+    } else if (std.mem.eql(u8, cmd, "set") or std.mem.eql(u8, cmd, "z")) {
+        var parsed = parseLabelSetArgs(alloc, &args) catch return help();
+        defer parsed.pairs.deinit(alloc);
+        if (parsed.pairs.items.len == 0) return help();
+        const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
+        defer alloc.free(sesh);
+        return labelSet(&cfg, sesh, parsed.pairs.items);
+    } else if (std.mem.eql(u8, cmd, "unset") or std.mem.eql(u8, cmd, "un")) {
+        var parsed = parseLabelKeyArgs(alloc, &args) catch return help();
+        defer parsed.keys.deinit(alloc);
+        if (parsed.keys.items.len == 0) return help();
+        const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
+        defer alloc.free(sesh);
+        return labelUnset(&cfg, sesh, parsed.keys.items);
+    } else if (std.mem.eql(u8, cmd, "clear") or std.mem.eql(u8, cmd, "cl")) {
+        const parsed = parseLabelKeyArgs(alloc, &args) catch return help();
+        const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
+        defer alloc.free(sesh);
+        return labelClear(&cfg, sesh);
     } else if (std.mem.eql(u8, cmd, "completions") or std.mem.eql(u8, cmd, "c")) {
         const arg = args.next() orelse return;
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
@@ -285,7 +415,7 @@ pub fn main() !void {
         if (matchers.items.len == 0) {
             return error.SessionNameRequired;
         }
-        var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
+        var sessions = try util.get_session_entries(alloc, cfg.socket_dir, false);
         defer {
             for (sessions.items) |session| {
                 session.deinit(alloc);
@@ -365,7 +495,7 @@ pub fn main() !void {
         }
 
         if (any_prefix) {
-            var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
+            var sessions = try util.get_session_entries(alloc, cfg.socket_dir, false);
             defer {
                 for (sessions.items) |session| {
                     session.deinit(alloc);
@@ -592,6 +722,46 @@ test "Cfg.init uses custom modes from env vars" {
     try std.testing.expectEqual(@as(u32, 0o660), cfg.log_mode);
 }
 
+test "parseWhereExpr: exact match" {
+    const f = parseWhereExpr("project=zmx").?;
+    try std.testing.expectEqualStrings("project", f.key);
+    try std.testing.expectEqualStrings("zmx", f.value);
+    try std.testing.expect(!f.is_prefix);
+}
+
+test "parseWhereExpr: prefix match with * suffix" {
+    const f = parseWhereExpr("start_dir=/Users/max*").?;
+    try std.testing.expectEqualStrings("start_dir", f.key);
+    try std.testing.expectEqualStrings("/Users/max", f.value);
+    try std.testing.expect(f.is_prefix);
+}
+
+test "parseWhereExpr: invalid" {
+    try std.testing.expect(parseWhereExpr("noequals") == null);
+    try std.testing.expect(parseWhereExpr("=nokey") == null);
+}
+
+test "whereMatch: exact" {
+    try std.testing.expect(whereMatch("hello", "hello", false));
+    try std.testing.expect(!whereMatch("hello", "hell", false));
+    try std.testing.expect(!whereMatch("hello", "hello world", false));
+}
+
+test "whereMatch: prefix" {
+    try std.testing.expect(whereMatch("/Users/max/code/zmx", "/Users/max", true));
+    try std.testing.expect(!whereMatch("/Users/max/code/zmx", "/code", true));
+    try std.testing.expect(whereMatch("hello", "", true));
+    try std.testing.expect(whereMatch("hello", "hello", true));
+}
+
+test "isReservedKey" {
+    try std.testing.expect(isReservedKey("name"));
+    try std.testing.expect(isReservedKey("start_dir"));
+    try std.testing.expect(isReservedKey("cmd"));
+    try std.testing.expect(!isReservedKey("project"));
+    try std.testing.expect(!isReservedKey("status"));
+}
+
 /// Daemon is responsible for managing a zmx session.
 ///
 /// It holds all the state for a running session.  Instead of a single daemon for all sessions, we
@@ -604,6 +774,7 @@ const Daemon = struct {
     cfg: *Cfg,
     alloc: std.mem.Allocator,
     clients: std.ArrayList(*Client),
+    labels: std.StringHashMapUnmanaged([]u8) = .empty,
     // This control which client is the leader.  The leader controls terminal state and
     // cols/rows of session.
     leader_client_fd: ?i32,
@@ -630,8 +801,92 @@ const Daemon = struct {
 
     pub fn deinit(self: *Daemon) void {
         self.clients.deinit(self.alloc);
+        var it = self.labels.iterator();
+        while (it.next()) |entry| {
+            self.alloc.free(entry.key_ptr.*);
+            self.alloc.free(entry.value_ptr.*);
+        }
+        self.labels.deinit(self.alloc);
         self.pty_write_buf.deinit(self.alloc);
         self.alloc.free(self.socket_path);
+    }
+
+    fn handleLabelGet(self: *Daemon, client: *Client) !void {
+        var out = std.ArrayList(u8).empty;
+        var keys = std.ArrayList([]const u8).empty;
+        defer out.deinit(self.alloc);
+        defer keys.deinit(self.alloc);
+
+        var it = self.labels.iterator();
+        while (it.next()) |entry| {
+            try keys.append(self.alloc, entry.key_ptr.*);
+        }
+        std.mem.sort([]const u8, keys.items, {}, struct {
+            fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                return std.mem.order(u8, a, b) == .lt;
+            }
+        }.lessThan);
+
+        for (keys.items) |key| {
+            const value = self.labels.get(key).?;
+            try out.appendSlice(self.alloc, key);
+            try out.append(self.alloc, '=');
+            try out.appendSlice(self.alloc, value);
+            try out.append(self.alloc, '\n');
+        }
+
+        try ipc.appendMessage(self.alloc, &client.write_buf, .LabelData, out.items);
+        client.has_pending_output = true;
+    }
+
+    fn handleLabelSet(self: *Daemon, client: *Client, payload: []const u8) !void {
+        var lines = std.mem.tokenizeScalar(u8, payload, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            const idx = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+            const key = line[0..idx];
+            const value = line[idx + 1 ..];
+            if (key.len == 0) continue;
+            if (isReservedKey(key)) continue;
+
+            const owned_key = try self.alloc.dupe(u8, key);
+            errdefer self.alloc.free(owned_key);
+            const owned_value = try self.alloc.dupe(u8, value);
+            errdefer self.alloc.free(owned_value);
+            if (try self.labels.fetchPut(self.alloc, owned_key, owned_value)) |existing| {
+                // fetchPut does NOT replace the key in the map — the old
+                // key pointer stays. So free the new (unused) key and the
+                // old value.
+                self.alloc.free(owned_key);
+                self.alloc.free(existing.value);
+            }
+        }
+        try ipc.appendMessage(self.alloc, &client.write_buf, .Ack, "");
+        client.has_pending_output = true;
+    }
+
+    fn handleLabelUnset(self: *Daemon, client: *Client, payload: []const u8) !void {
+        var lines = std.mem.tokenizeScalar(u8, payload, '\n');
+        while (lines.next()) |line| {
+            if (line.len == 0) continue;
+            if (self.labels.fetchRemove(line)) |existing| {
+                self.alloc.free(existing.key);
+                self.alloc.free(existing.value);
+            }
+        }
+        try ipc.appendMessage(self.alloc, &client.write_buf, .Ack, "");
+        client.has_pending_output = true;
+    }
+
+    fn handleLabelClear(self: *Daemon, client: *Client) !void {
+        var it = self.labels.iterator();
+        while (it.next()) |entry| {
+            self.alloc.free(entry.key_ptr.*);
+            self.alloc.free(entry.value_ptr.*);
+        }
+        self.labels.clearRetainingCapacity();
+        try ipc.appendMessage(self.alloc, &client.write_buf, .Ack, "");
+        client.has_pending_output = true;
     }
 
     pub fn shutdown(self: *Daemon) void {
@@ -1287,7 +1542,11 @@ fn help() !void {
         \\  [p]rint <name> <text...>                 Inject text into session display
         \\  [wr]ite <name> <file_path>               Write stdin to file_path through the session
         \\  [d]etach                                 Detach all clients (ctrl+\\ for current client)
-        \\  [l]ist|ls [--short]                      List active sessions
+        \\  [l]ist|ls [--short|--where k=v]           List active sessions
+        \\  [g]et <name>                              Get session labels
+        \\  set|z <name> k=v ...                       Set session labels
+        \\  [un]set <name> key ...                    Remove session labels
+        \\  [cl]ear <name>                            Clear all session labels
         \\  [k]ill <name>... [--force]               Kill session and all attached clients
         \\  [hi]story <name> [--vt|--html]           Output session scrollback
         \\  [w]ait <name>...                         Wait for session tasks to complete
@@ -1554,7 +1813,7 @@ fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
     var prev_done: i32 = 0;
     while (true) {
         agg_exit_code = 0;
-        var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
+        var sessions = try util.get_session_entries(alloc, cfg.socket_dir, false);
         var total: i32 = 0;
         var done: i32 = 0;
 
@@ -1659,7 +1918,7 @@ fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
     }
     try stdout.flush();
 
-    const sessions = try util.get_session_entries(alloc, cfg.socket_dir);
+    const sessions = try util.get_session_entries(alloc, cfg.socket_dir, false);
     for (sessions.items) |session| {
         var found = false;
         for (matchers.items) |m| {
@@ -1712,7 +1971,7 @@ fn wait(cfg: *Cfg, matchers: std.ArrayList(SessionMatch)) !void {
     std.process.exit(agg_exit_code);
 }
 
-fn list(cfg: *Cfg, short: bool) !void {
+fn list(cfg: *Cfg, short: bool, where_filters: []const WhereFilter) !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const alloc = gpa.allocator();
@@ -1721,7 +1980,13 @@ fn list(cfg: *Cfg, short: bool) !void {
     var buf: [4096]u8 = undefined;
     var stdout = std.fs.File.stdout().writer(&buf);
 
-    var sessions = try util.get_session_entries(alloc, cfg.socket_dir);
+    const need_labels = !short or blk: {
+        for (where_filters) |filter| {
+            if (!isReservedKey(filter.key)) break :blk true;
+        }
+        break :blk false;
+    };
+    var sessions = try util.get_session_entries(alloc, cfg.socket_dir, need_labels);
     defer {
         for (sessions.items) |session| {
             session.deinit(alloc);
@@ -1740,10 +2005,86 @@ fn list(cfg: *Cfg, short: bool) !void {
 
     std.mem.sort(util.SessionEntry, sessions.items, {}, util.SessionEntry.lessThan);
 
+    const has_filters = where_filters.len > 0;
+
     for (sessions.items) |session| {
-        try util.writeSessionLine(&stdout.interface, session, short, current_session);
+        if (session.is_error) {
+            if (!has_filters) {
+                try util.writeSessionLine(&stdout.interface, session, short, current_session, false);
+                try stdout.interface.flush();
+            }
+            continue;
+        }
+
+        // Apply --where filters
+        if (has_filters) {
+            var match = true;
+            for (where_filters) |filter| {
+                if (!sessionMatchesFilter(session, filter, session.labels)) {
+                    match = false;
+                    break;
+                }
+            }
+            if (!match) continue;
+        }
+
+        const append_labels = !short;
+        try util.writeSessionLine(&stdout.interface, session, short, current_session, append_labels);
+
+        if (append_labels) {
+            if (session.labels) |payload| {
+                if (payload.len > 0) {
+                    var lines = std.mem.tokenizeScalar(u8, payload, '\n');
+                    while (lines.next()) |line| {
+                        try stdout.interface.print("\t{s}", .{line});
+                    }
+                }
+            }
+            try stdout.interface.print("\n", .{});
+        }
         try stdout.interface.flush();
     }
+}
+
+/// Parse a where expression: "key=value" for exact match, "key=value*" for prefix match.
+fn parseWhereExpr(expr: []const u8) ?WhereFilter {
+    const idx = std.mem.indexOfScalar(u8, expr, '=') orelse return null;
+    if (idx == 0) return null;
+    const key = expr[0..idx];
+    const raw_value = expr[idx + 1 ..];
+    const is_prefix = raw_value.len > 0 and raw_value[raw_value.len - 1] == '*';
+    const value = if (is_prefix) raw_value[0 .. raw_value.len - 1] else raw_value;
+    return .{ .key = key, .value = value, .is_prefix = is_prefix };
+}
+
+fn whereMatch(value: []const u8, filter_value: []const u8, is_prefix: bool) bool {
+    if (is_prefix) return std.mem.startsWith(u8, value, filter_value);
+    return std.mem.eql(u8, value, filter_value);
+}
+
+/// Resolve a where filter against built-in session fields and label payload.
+fn sessionMatchesFilter(session: util.SessionEntry, filter: WhereFilter, labels: ?[]const u8) bool {
+    // Check built-in fields first
+    if (std.mem.eql(u8, filter.key, "name")) return whereMatch(session.name, filter.value, filter.is_prefix);
+    if (std.mem.eql(u8, filter.key, "start_dir")) {
+        if (session.cwd) |cwd| return whereMatch(cwd, filter.value, filter.is_prefix);
+        return false;
+    }
+    if (std.mem.eql(u8, filter.key, "cmd")) {
+        if (session.cmd) |cmd| return whereMatch(cmd, filter.value, filter.is_prefix);
+        return false;
+    }
+
+    // Check label payload
+    const payload = labels orelse return false;
+    var lines = std.mem.tokenizeScalar(u8, payload, '\n');
+    while (lines.next()) |line| {
+        const idx = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        const lk = line[0..idx];
+        const lv = line[idx + 1 ..];
+        if (std.mem.eql(u8, lk, filter.key) and whereMatch(lv, filter.value, filter.is_prefix)) return true;
+    }
+    return false;
 }
 
 fn detachAll(cfg: *Cfg) !void {
@@ -1836,6 +2177,121 @@ fn kill(cfg: *Cfg, session_name: []const u8, force: bool) !void {
     var w = std.fs.File.stdout().writer(&buf);
     try w.interface.print("killed session {s}\n", .{session_name});
     try w.interface.flush();
+}
+
+fn printLabelError(session_name: []const u8, err: anyerror) noreturn {
+    var buf: [4096]u8 = undefined;
+    var w = std.fs.File.stderr().writer(&buf);
+    switch (err) {
+        error.Timeout => w.interface.print(
+            "error: session \"{s}\" does not support labels (daemon too old?)\n",
+            .{session_name},
+        ) catch {},
+        error.ConnectionRefused, error.Unexpected => w.interface.print(
+            "error: session \"{s}\" not found or unresponsive\n",
+            .{session_name},
+        ) catch {},
+        else => w.interface.print(
+            "error: {s}\n",
+            .{@errorName(err)},
+        ) catch {},
+    }
+    w.interface.flush() catch {};
+    std.process.exit(1);
+}
+
+fn labelGet(cfg: *Cfg, session_name: []const u8) !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
+        error.NameTooLong => return socket.printSessionNameTooLong(session_name, cfg.socket_dir),
+        error.OutOfMemory => return err,
+    };
+    defer alloc.free(socket_path);
+
+    const payload = ipc.roundTripForTag(alloc, socket_path, .LabelGet, "", .LabelData) catch |err| {
+        printLabelError(session_name, err);
+    };
+    defer alloc.free(payload);
+
+    var buf: [4096]u8 = undefined;
+    var stdout = std.fs.File.stdout().writer(&buf);
+    try stdout.interface.print("{s}", .{payload});
+    try stdout.interface.flush();
+}
+
+const reserved_keys = [_][]const u8{ "name", "start_dir", "cmd" };
+
+fn isReservedKey(key: []const u8) bool {
+    for (reserved_keys) |rk| {
+        if (std.mem.eql(u8, key, rk)) return true;
+    }
+    return false;
+}
+
+fn labelSet(cfg: *Cfg, session_name: []const u8, pairs: []const LabelKeyValue) !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    // Reject reserved built-in keys
+    for (pairs) |pair| {
+        if (isReservedKey(pair.key)) {
+            var buf: [4096]u8 = undefined;
+            var w = std.fs.File.stderr().writer(&buf);
+            w.interface.print("error: \"{s}\" is a read-only built-in field\n", .{pair.key}) catch {};
+            w.interface.flush() catch {};
+            std.process.exit(1);
+        }
+    }
+
+    const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
+        error.NameTooLong => return socket.printSessionNameTooLong(session_name, cfg.socket_dir),
+        error.OutOfMemory => return err,
+    };
+    defer alloc.free(socket_path);
+
+    const payload = try serializeLabelSet(alloc, pairs);
+    defer alloc.free(payload);
+    _ = ipc.roundTripForTag(alloc, socket_path, .LabelSet, payload, .Ack) catch |err| {
+        printLabelError(session_name, err);
+    };
+}
+
+fn labelUnset(cfg: *Cfg, session_name: []const u8, keys: []const []const u8) !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
+        error.NameTooLong => return socket.printSessionNameTooLong(session_name, cfg.socket_dir),
+        error.OutOfMemory => return err,
+    };
+    defer alloc.free(socket_path);
+
+    const payload = try serializeLabelKeys(alloc, keys);
+    defer alloc.free(payload);
+    _ = ipc.roundTripForTag(alloc, socket_path, .LabelUnset, payload, .Ack) catch |err| {
+        printLabelError(session_name, err);
+    };
+}
+
+fn labelClear(cfg: *Cfg, session_name: []const u8) !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const alloc = gpa.allocator();
+
+    const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
+        error.NameTooLong => return socket.printSessionNameTooLong(session_name, cfg.socket_dir),
+        error.OutOfMemory => return err,
+    };
+    defer alloc.free(socket_path);
+
+    _ = ipc.roundTripForTag(alloc, socket_path, .LabelClear, "", .Ack) catch |err| {
+        printLabelError(session_name, err);
+    };
 }
 
 /// Fetch terminal history from a session socket, returning it as an allocated
@@ -2748,9 +3204,13 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                             break :daemon_loop;
                         },
                         .Info => try daemon.handleInfo(client),
+                        .LabelGet => try daemon.handleLabelGet(client),
+                        .LabelSet => try daemon.handleLabelSet(client, msg.payload),
+                        .LabelUnset => try daemon.handleLabelUnset(client, msg.payload),
+                        .LabelClear => try daemon.handleLabelClear(client),
                         .History => try daemon.handleHistory(client, &term, msg.payload),
                         .Run => try daemon.handleRun(client, msg.payload),
-                        .Ack, .TaskComplete => {},
+                        .Ack, .TaskComplete, .LabelData => {},
                         .Write => try daemon.handleWrite(client, msg.payload),
                         _ => std.log.warn(
                             "ignoring unknown IPC tag={d}",

--- a/src/main.zig
+++ b/src/main.zig
@@ -100,38 +100,12 @@ fn parseLabelSetArgs(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !
     return .{ .session_name = session_name, .pairs = pairs };
 }
 
-fn parseLabelKeyArgs(alloc: std.mem.Allocator, args: *std.process.ArgIterator) !struct {
-    session_name: ?[]const u8,
-    keys: std.ArrayList([]const u8),
-} {
-    var session_name: ?[]const u8 = null;
-    var keys: std.ArrayList([]const u8) = .empty;
-    while (args.next()) |arg| {
-        if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) return error.InvalidArgument;
-        if (session_name == null and std.mem.indexOfScalar(u8, arg, '=' ) == null and keys.items.len == 0) {
-            session_name = arg;
-        } else {
-            try keys.append(alloc, arg);
-        }
-    }
-    return .{ .session_name = session_name, .keys = keys };
-}
-
 fn serializeLabelSet(alloc: std.mem.Allocator, pairs: []const LabelKeyValue) ![]u8 {
     var out = std.ArrayList(u8).empty;
     for (pairs) |pair| {
         try out.appendSlice(alloc, pair.key);
         try out.append(alloc, '=');
         try out.appendSlice(alloc, pair.value);
-        try out.append(alloc, '\n');
-    }
-    return out.toOwnedSlice(alloc);
-}
-
-fn serializeLabelKeys(alloc: std.mem.Allocator, keys: []const []const u8) ![]u8 {
-    var out = std.ArrayList(u8).empty;
-    for (keys) |key| {
-        try out.appendSlice(alloc, key);
         try out.append(alloc, '\n');
     }
     return out.toOwnedSlice(alloc);
@@ -212,8 +186,8 @@ pub fn main() !void {
         }
         return list(&cfg, short, where_filters.items);
     } else if (std.mem.eql(u8, cmd, "get") or std.mem.eql(u8, cmd, "g")) {
-        var parsed = parseLabelKeyArgs(alloc, &args) catch return help();
-        defer parsed.keys.deinit(alloc);
+        var parsed = parseLabelSetArgs(alloc, &args) catch return help();
+        defer parsed.pairs.deinit(alloc);
         const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
         defer alloc.free(sesh);
         return labelGet(&cfg, sesh);
@@ -224,15 +198,9 @@ pub fn main() !void {
         const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
         defer alloc.free(sesh);
         return labelSet(&cfg, sesh, parsed.pairs.items);
-    } else if (std.mem.eql(u8, cmd, "unset") or std.mem.eql(u8, cmd, "un")) {
-        var parsed = parseLabelKeyArgs(alloc, &args) catch return help();
-        defer parsed.keys.deinit(alloc);
-        if (parsed.keys.items.len == 0) return help();
-        const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
-        defer alloc.free(sesh);
-        return labelUnset(&cfg, sesh, parsed.keys.items);
     } else if (std.mem.eql(u8, cmd, "clear") or std.mem.eql(u8, cmd, "cl")) {
-        const parsed = parseLabelKeyArgs(alloc, &args) catch return help();
+        var parsed = parseLabelSetArgs(alloc, &args) catch return help();
+        defer parsed.pairs.deinit(alloc);
         const sesh = resolveSessionOrEnv(alloc, parsed.session_name) catch return;
         defer alloc.free(sesh);
         return labelClear(&cfg, sesh);
@@ -304,6 +272,7 @@ pub fn main() !void {
             error.OutOfMemory => return err,
         };
         std.log.info("socket path={s}", .{daemon.socket_path});
+        inheritParentLabels(&daemon);
         return attach(&daemon);
     } else if (std.mem.eql(u8, cmd, "run") or std.mem.eql(u8, cmd, "r")) {
         const session_name = args.next() orelse "";
@@ -317,9 +286,9 @@ pub fn main() !void {
         while (args.next()) |arg| {
             if (std.mem.startsWith(u8, arg, "-d")) {
                 detached = true;
-                continue;
+            } else {
+                try cmd_args_raw.append(alloc, arg);
             }
-            try cmd_args_raw.append(alloc, arg);
         }
         const clients = try std.ArrayList(*Client).initCapacity(alloc, 10);
 
@@ -347,6 +316,7 @@ pub fn main() !void {
             error.OutOfMemory => return err,
         };
         std.log.info("socket path={s}", .{daemon.socket_path});
+        inheritParentLabels(&daemon);
         return run(&daemon, detached, cmd_args_raw.items);
     } else if (std.mem.eql(u8, cmd, "send") or std.mem.eql(u8, cmd, "s")) {
         const session_name = args.next() orelse "";
@@ -571,6 +541,7 @@ pub fn main() !void {
             error.OutOfMemory => return err,
         };
         std.log.info("socket path={s}", .{daemon.socket_path});
+        inheritParentLabels(&daemon);
         try writeFile(&daemon, file_path);
     } else {
         return help();
@@ -849,6 +820,15 @@ const Daemon = struct {
             if (key.len == 0) continue;
             if (isReservedKey(key)) continue;
 
+            // ponytail: empty value = remove the key
+            if (value.len == 0) {
+                if (self.labels.fetchRemove(key)) |existing| {
+                    self.alloc.free(existing.key);
+                    self.alloc.free(existing.value);
+                }
+                continue;
+            }
+
             const owned_key = try self.alloc.dupe(u8, key);
             errdefer self.alloc.free(owned_key);
             const owned_value = try self.alloc.dupe(u8, value);
@@ -858,19 +838,6 @@ const Daemon = struct {
                 // key pointer stays. So free the new (unused) key and the
                 // old value.
                 self.alloc.free(owned_key);
-                self.alloc.free(existing.value);
-            }
-        }
-        try ipc.appendMessage(self.alloc, &client.write_buf, .Ack, "");
-        client.has_pending_output = true;
-    }
-
-    fn handleLabelUnset(self: *Daemon, client: *Client, payload: []const u8) !void {
-        var lines = std.mem.tokenizeScalar(u8, payload, '\n');
-        while (lines.next()) |line| {
-            if (line.len == 0) continue;
-            if (self.labels.fetchRemove(line)) |existing| {
-                self.alloc.free(existing.key);
                 self.alloc.free(existing.value);
             }
         }
@@ -1544,8 +1511,7 @@ fn help() !void {
         \\  [d]etach                                 Detach all clients (ctrl+\\ for current client)
         \\  [l]ist|ls [--short|--where k=v]           List active sessions
         \\  [g]et <name>                              Get session labels
-        \\  set|z <name> k=v ...                       Set session labels
-        \\  [un]set <name> key ...                    Remove session labels
+        \\  set|z <name> k=v ...                       Set session labels (k= to remove)
         \\  [cl]ear <name>                            Clear all session labels
         \\  [k]ill <name>... [--force]               Kill session and all attached clients
         \\  [hi]story <name> [--vt|--html]           Output session scrollback
@@ -1649,6 +1615,7 @@ fn help() !void {
         \\  TMPDIR               Socket directory (priority 3)
         \\  ZMX_SESSION          Session name (injected automatically)
         \\  ZMX_SESSION_PREFIX   Prefix added to all session names
+        \\  ZMX_INHERIT_LABELS   Label inheritance filter (unset=all, empty=none, "a,b"=allowlist)
         \\  ZMX_DIR_MODE         Sets mode for socket and log directories (octal, defaults to 0750)
         \\  ZMX_LOG_MODE         Sets mode for log files (octal, defaults to 0640)
         \\
@@ -2200,6 +2167,60 @@ fn printLabelError(session_name: []const u8, err: anyerror) noreturn {
     std.process.exit(1);
 }
 
+/// ponytail: inherit labels from parent session into a newly created daemon.
+/// Uses $ZMX_SESSION if set, silently skips otherwise.
+/// ZMX_INHERIT_LABELS controls filtering:
+///   unset        → inherit all
+///   empty string → inherit nothing
+///   "a,b"        → inherit only keys a and b
+fn inheritParentLabels(daemon: *Daemon) void {
+    const parent_name = std.posix.getenv("ZMX_SESSION") orelse return;
+    if (parent_name.len == 0) return;
+
+    // Empty value = opt out entirely. Non-empty = comma-separated allowlist.
+    const filter_env = std.posix.getenv("ZMX_INHERIT_LABELS");
+    if (filter_env) |f| {
+        if (f.len == 0) return;
+    }
+
+    const parent_socket = socket.getSocketPath(daemon.alloc, daemon.cfg.socket_dir, parent_name) catch return;
+    defer daemon.alloc.free(parent_socket);
+
+    const result = ipc.probeSessionWithLabels(daemon.alloc, parent_socket, true) catch return;
+    posix.close(result.fd);
+    const label_data = result.labels orelse return;
+    defer daemon.alloc.free(label_data);
+
+    var lines = std.mem.tokenizeScalar(u8, label_data, '\n');
+    while (lines.next()) |line| {
+        const sep = std.mem.indexOfScalar(u8, line, '=') orelse continue;
+        const key = line[0..sep];
+
+        // If filter is set, skip keys not in the allowlist.
+        if (filter_env) |f| {
+            var it = std.mem.tokenizeScalar(u8, f, ',');
+            var found = false;
+            while (it.next()) |allowed| {
+                if (std.mem.eql(u8, allowed, key)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) continue;
+        }
+
+        const owned_key = daemon.alloc.dupe(u8, key) catch continue;
+        const owned_val = daemon.alloc.dupe(u8, line[sep + 1 ..]) catch {
+            daemon.alloc.free(owned_key);
+            continue;
+        };
+        daemon.labels.put(daemon.alloc, owned_key, owned_val) catch {
+            daemon.alloc.free(owned_key);
+            daemon.alloc.free(owned_val);
+        };
+    }
+}
+
 fn labelGet(cfg: *Cfg, session_name: []const u8) !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
@@ -2256,24 +2277,6 @@ fn labelSet(cfg: *Cfg, session_name: []const u8, pairs: []const LabelKeyValue) !
     const payload = try serializeLabelSet(alloc, pairs);
     defer alloc.free(payload);
     _ = ipc.roundTripForTag(alloc, socket_path, .LabelSet, payload, .Ack) catch |err| {
-        printLabelError(session_name, err);
-    };
-}
-
-fn labelUnset(cfg: *Cfg, session_name: []const u8, keys: []const []const u8) !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
-    defer _ = gpa.deinit();
-    const alloc = gpa.allocator();
-
-    const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
-        error.NameTooLong => return socket.printSessionNameTooLong(session_name, cfg.socket_dir),
-        error.OutOfMemory => return err,
-    };
-    defer alloc.free(socket_path);
-
-    const payload = try serializeLabelKeys(alloc, keys);
-    defer alloc.free(payload);
-    _ = ipc.roundTripForTag(alloc, socket_path, .LabelUnset, payload, .Ack) catch |err| {
         printLabelError(session_name, err);
     };
 }
@@ -3206,7 +3209,6 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                         .Info => try daemon.handleInfo(client),
                         .LabelGet => try daemon.handleLabelGet(client),
                         .LabelSet => try daemon.handleLabelSet(client, msg.payload),
-                        .LabelUnset => try daemon.handleLabelUnset(client, msg.payload),
                         .LabelClear => try daemon.handleLabelClear(client),
                         .History => try daemon.handleHistory(client, &term, msg.payload),
                         .Run => try daemon.handleRun(client, msg.payload),

--- a/src/util.zig
+++ b/src/util.zig
@@ -13,6 +13,7 @@ pub const SessionEntry = struct {
     error_name: ?[]const u8,
     cmd: ?[]const u8 = null,
     cwd: ?[]const u8 = null,
+    labels: ?[]const u8 = null,
     created_at: u64,
     task_ended_at: ?u64,
     task_exit_code: ?u8,
@@ -21,6 +22,7 @@ pub const SessionEntry = struct {
         alloc.free(self.name);
         if (self.cmd) |cmd| alloc.free(cmd);
         if (self.cwd) |cwd| alloc.free(cwd);
+        if (self.labels) |l| alloc.free(l);
     }
 
     pub fn lessThan(_: void, a: SessionEntry, b: SessionEntry) bool {
@@ -31,6 +33,7 @@ pub const SessionEntry = struct {
 pub fn get_session_entries(
     alloc: std.mem.Allocator,
     socket_dir: []const u8,
+    fetch_labels: bool,
 ) !std.ArrayList(SessionEntry) {
     var dir = try std.fs.openDirAbsolute(socket_dir, .{ .iterate = true });
     defer dir.close();
@@ -50,7 +53,7 @@ pub fn get_session_entries(
             };
             defer alloc.free(socket_path);
 
-            const result = ipc.probeSession(alloc, socket_path) catch |err| {
+            const result = ipc.probeSessionWithLabels(alloc, socket_path, fetch_labels) catch |err| {
                 try sessions.append(alloc, .{
                     .name = name,
                     .pid = null,
@@ -69,6 +72,7 @@ pub fn get_session_entries(
                 }
                 continue;
             };
+            const labels = result.labels;
             posix.close(result.fd);
 
             // Extract cmd and cwd from the fixed-size arrays. Lengths come
@@ -92,6 +96,7 @@ pub fn get_session_entries(
                 .error_name = null,
                 .cmd = cmd,
                 .cwd = cwd,
+                .labels = labels,
                 .created_at = result.info.created_at,
                 .task_ended_at = result.info.task_ended_at,
                 .task_exit_code = result.info.task_exit_code,
@@ -682,6 +687,7 @@ pub fn writeSessionLine(
     session: SessionEntry,
     short: bool,
     current_session: ?[]const u8,
+    omit_newline: bool,
 ) !void {
     const current_arrow = "→";
     const prefix = if (current_session) |current|
@@ -734,7 +740,7 @@ pub fn writeSessionLine(
             }
         }
     }
-    try writer.print("\n", .{});
+    if (!omit_newline) try writer.print("\n", .{});
 }
 
 test "writeSessionLine formats output for current session and short output" {
@@ -801,7 +807,7 @@ test "writeSessionLine formats output for current session and short output" {
         var builder: std.Io.Writer.Allocating = .init(testing.allocator);
         defer builder.deinit();
 
-        try writeSessionLine(&builder.writer, case.session, case.short, case.current_session);
+        try writeSessionLine(&builder.writer, case.session, case.short, case.current_session, false);
         try testing.expectEqualStrings(case.expected, builder.writer.buffered());
     }
 }

--- a/test/labels.bats
+++ b/test/labels.bats
@@ -62,12 +62,12 @@ load test_helper
   [[ "$output" == *"read-only built-in field"* ]]
 }
 
-@test "unset: removes specific label" {
+@test "set with empty value removes label" {
   "$ZMX" run test-unset -d sleep 30
   wait_for_session test-unset
 
   run "$ZMX" set test-unset a=1 b=2
-  run "$ZMX" unset test-unset a
+  run "$ZMX" set test-unset a=
 
   run "$ZMX" get test-unset
   [ "$status" -eq 0 ]
@@ -159,6 +159,56 @@ load test_helper
   [ "$status" -eq 0 ]
   [[ "$output" == *"test-bpfx"* ]]
 }
+
+# ============================================================================
+# Label inheritance
+# ============================================================================
+
+@test "inherit: child session inherits parent labels by default" {
+  "$ZMX" run test-parent -d sleep 30
+  wait_for_session test-parent
+  "$ZMX" set test-parent project=zmx env=dev
+
+  # Create a child session from inside the parent's env
+  ZMX_SESSION=test-parent "$ZMX" run test-child -d sleep 30
+  wait_for_session test-child
+
+  run "$ZMX" get test-child
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"project=zmx"* ]]
+  [[ "$output" == *"env=dev"* ]]
+}
+
+@test "inherit: ZMX_INHERIT_LABELS= disables inheritance" {
+  "$ZMX" run test-parent2 -d sleep 30
+  wait_for_session test-parent2
+  "$ZMX" set test-parent2 project=zmx env=dev
+
+  ZMX_SESSION=test-parent2 ZMX_INHERIT_LABELS= "$ZMX" run test-noinherit -d sleep 30
+  wait_for_session test-noinherit
+
+  run "$ZMX" get test-noinherit
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"project=zmx"* ]]
+  [[ "$output" != *"env=dev"* ]]
+}
+
+
+@test "inherit: ZMX_INHERIT_LABELS=key filters to allowlist" {
+  "$ZMX" run test-parent3 -d sleep 30
+  wait_for_session test-parent3
+  "$ZMX" set test-parent3 project=zmx env=dev team=core
+
+  ZMX_SESSION=test-parent3 ZMX_INHERIT_LABELS=project,team "$ZMX" run test-filtered -d sleep 30
+  wait_for_session test-filtered
+
+  run "$ZMX" get test-filtered
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"project=zmx"* ]]
+  [[ "$output" == *"team=core"* ]]
+  [[ "$output" != *"env=dev"* ]]
+}
+
 
 @test "list --where: no match returns empty" {
   "$ZMX" run test-nomatch -d sleep 30

--- a/test/labels.bats
+++ b/test/labels.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+# Label tests for zmx.
+
+load test_helper
+
+# ============================================================================
+# Label CRUD
+# ============================================================================
+
+@test "set/get: round-trips labels" {
+  "$ZMX" run test-labels -d sleep 30
+  wait_for_session test-labels
+
+  run "$ZMX" set test-labels project=zmx env=dev
+  [ "$status" -eq 0 ]
+
+  run "$ZMX" get test-labels
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"env=dev"* ]]
+  [[ "$output" == *"project=zmx"* ]]
+}
+
+@test "set: updates existing label" {
+  "$ZMX" run test-update -d sleep 30
+  wait_for_session test-update
+
+  run "$ZMX" set test-update status=busy
+  [ "$status" -eq 0 ]
+  run "$ZMX" set test-update status=done
+  [ "$status" -eq 0 ]
+
+  run "$ZMX" get test-update
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"status=done"* ]]
+  [[ "$output" != *"status=busy"* ]]
+}
+
+@test "set: rejects reserved key 'name'" {
+  "$ZMX" run test-reserved -d sleep 30
+  wait_for_session test-reserved
+
+  run "$ZMX" set test-reserved name=bad
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"read-only built-in field"* ]]
+}
+
+@test "set: rejects reserved key 'start_dir'" {
+  "$ZMX" run test-reserved2 -d sleep 30
+  wait_for_session test-reserved2
+
+  run "$ZMX" set test-reserved2 start_dir=/tmp
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"read-only built-in field"* ]]
+}
+
+@test "set: rejects reserved key 'cmd'" {
+  "$ZMX" run test-reserved3 -d sleep 30
+  wait_for_session test-reserved3
+
+  run "$ZMX" set test-reserved3 cmd=bad
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"read-only built-in field"* ]]
+}
+
+@test "unset: removes specific label" {
+  "$ZMX" run test-unset -d sleep 30
+  wait_for_session test-unset
+
+  run "$ZMX" set test-unset a=1 b=2
+  run "$ZMX" unset test-unset a
+
+  run "$ZMX" get test-unset
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"a=1"* ]]
+  [[ "$output" == *"b=2"* ]]
+}
+
+@test "clear: removes all labels" {
+  "$ZMX" run test-clear -d sleep 30
+  wait_for_session test-clear
+
+  run "$ZMX" set test-clear x=1 y=2
+  run "$ZMX" clear test-clear
+
+  run "$ZMX" get test-clear
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "get: no session prints error" {
+  run "$ZMX" get nonexistent
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"not found"* ]]
+}
+
+@test "get: no args prints error" {
+  run env -u ZMX_SESSION "$ZMX" get
+  [[ "$output" == *"session name required"* ]]
+}
+
+# ============================================================================
+# List with labels and --where
+# ============================================================================
+
+@test "list: shows labels in output" {
+  "$ZMX" run test-show -d sleep 30
+  wait_for_session test-show
+
+  run "$ZMX" set test-show project=zmx
+
+  run "$ZMX" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"project=zmx"* ]]
+}
+
+@test "list --where: exact match on label" {
+  "$ZMX" run test-where1 -d sleep 30
+  "$ZMX" run test-where2 -d sleep 30
+  wait_for_session test-where1
+  wait_for_session test-where2
+
+  run "$ZMX" set test-where1 role=web
+  run "$ZMX" set test-where2 role=api
+
+  run "$ZMX" list --short --where role=web
+  [ "$status" -eq 0 ]
+  [[ "$output" == "test-where1" ]]
+}
+
+@test "list --where: prefix match with * suffix" {
+  "$ZMX" run test-pfx1 -d sleep 30
+  "$ZMX" run test-pfx2 -d sleep 30
+  wait_for_session test-pfx1
+  wait_for_session test-pfx2
+
+  run "$ZMX" set test-pfx1 path=/Users/max/code/zmx
+  run "$ZMX" set test-pfx2 path=/Users/max/code/jbang
+
+  run "$ZMX" list --short --where 'path=/Users/max/code*'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test-pfx1"* ]]
+  [[ "$output" == *"test-pfx2"* ]]
+}
+
+@test "list --where: exact match on builtin name" {
+  "$ZMX" run test-builtin -d sleep 30
+  wait_for_session test-builtin
+
+  run "$ZMX" list --short --where name=test-builtin
+  [ "$status" -eq 0 ]
+  [[ "$output" == "test-builtin" ]]
+}
+
+@test "list --where: prefix match on builtin name" {
+  "$ZMX" run test-bpfx -d sleep 30
+  wait_for_session test-bpfx
+
+  run "$ZMX" list --short --where 'name=test-b*'
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"test-bpfx"* ]]
+}
+
+@test "list --where: no match returns empty" {
+  "$ZMX" run test-nomatch -d sleep 30
+  wait_for_session test-nomatch
+
+  run "$ZMX" list --short --where role=nonexistent
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}


### PR DESCRIPTION
Implements #183 — session labels for discovery and filtering.

Fair warning: this is my first time writing Zig, so treat this as a "works but could use a more experienced eye on idioms" kind of PR. Happy to adjust anything that doesn't fit zmx conventions.

## What this adds

Key-value labels that live on the session daemon, scoped to the session lifetime. Four new top-level commands:

```
zmx set mysession project=zmx env=dev
zmx get mysession
zmx unset mysession env
zmx clear mysession
```

Inside a session, `.` resolves via `$ZMX_SESSION`:

```
zmx set . status=busy
```

Labels show up automatically in `zmx list` output as extra tab-separated fields.

## Filtering with `--where`

```bash
zmx list --where project=zmx          # exact match
zmx list --where start_dir=/code/zmx* # prefix match (trailing *)
zmx list --short --where name=build*  # just names, for scripting
```

Built-in fields `name`, `start_dir`, and `cmd` work as virtual labels in `--where` queries without setting anything — so `zmx list --where start_dir=/Users/max/code*` works out of the box. These fields are read-only; `zmx set mysession name=foo` is rejected.

Multiple `--where` flags combine with AND logic.

## How it works

- Five new IPC tags: `LabelGet`, `LabelSet`, `LabelUnset`, `LabelClear`, `LabelData`. Old daemons silently ignore unknown tags via the existing `_` arm, so there's no backward compat issue.
- `zmx list` sends both `Info` and `LabelGet` in a single batch on the same socket connection. If the daemon responds with `LabelData`, great. If not (old daemon), a 50ms poll times out and we move on. No extra connection per session.
- When `--where` only filters on built-in fields, label fetching is skipped entirely — same speed as before.

## What's included

- IPC layer: new tags, `probeSessionWithLabels` for batched Info+Label fetch, `roundTripForTag` for single-session label ops
- Daemon: in-memory `StringHashMapUnmanaged` label store with proper allocation/deallocation
- CLI: `get`/`set`/`unset`/`clear` commands with aliases (`g`, `z`, `un`, `cl`)
- `list --where` with exact and prefix matching
- Reserved key protection (client-side and daemon-side)
- Error messages instead of stack traces for missing sessions, old daemons, `.` without `$ZMX_SESSION`
- Shell completions for all four shells (bash, zsh, fish, nu)
- 15 BATS integration tests covering CRUD, reserved keys, error paths, and `--where` filtering
- 6 unit tests for `parseWhereExpr`, `whereMatch`, and `isReservedKey`
- README section and CHANGELOG entry

## Build fix

The ghostty dependency was trying to build an iOS XCFramework on macOS without full Xcode. Added `emit-lib-vt=true`, `emit-xcframework=false`, `emit-macos-app=false` to all three `b.dependency("ghostty", ...)` calls. This might already be fixed upstream — just needed it to build locally with Command Line Tools only.