### PR TITLE
fix: avoid statx syscall so zmx runs on pre-4.11 kernels (#186)

### DIFF
--- a/src/log.zig
+++ b/src/log.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const posix = std.posix;
 
 pub const LogSystem = struct {
     file: ?std.fs.File = null,
@@ -22,7 +23,9 @@ pub const LogSystem = struct {
             else => return err,
         };
 
-        const end_pos = try file.getEndPos();
+        // fstat (not getEndPos) to avoid the statx syscall; see #186.
+        const st = try posix.fstat(file.handle);
+        const end_pos: u64 = @intCast(st.size);
         try file.seekTo(end_pos);
         self.current_size = end_pos;
         self.file = file;

--- a/src/socket.zig
+++ b/src/socket.zig
@@ -44,11 +44,13 @@ pub fn cleanupStaleSocket(dir: std.fs.Dir, session_name: []const u8) void {
 }
 
 pub fn sessionExists(dir: std.fs.Dir, name: []const u8) !bool {
-    const stat = dir.statFile(name) catch |err| switch (err) {
+    // fstatatZ (not statFile) to avoid the statx syscall; see #186.
+    const name_c = try posix.toPosixPath(name);
+    const stat = posix.fstatatZ(dir.fd, &name_c, posix.AT.SYMLINK_NOFOLLOW) catch |err| switch (err) {
         error.FileNotFound => return false,
         else => return err,
     };
-    if (stat.kind != .unix_domain_socket) {
+    if (!posix.S.ISSOCK(stat.mode)) {
         return error.FileNotUnixSocket;
     }
     return true;


### PR DESCRIPTION
zmx crashed with `error: Unexpected` on every invocation on a Synology DiskStation (Linux 4.4.302). `error.Unexpected` is what Zig's std returns for an unrecognized errno; here the errno is ENOSYS (38) from the `statx` syscall, which only exists on Linux >= 4.11.

Two code paths issued statx via Zig std, which calls the raw statx syscall directly and does not fall back like libc does:

  - log.zig: LogSystem.init() called file.getEndPos() -> File.stat() -> statx. This runs before command parsing, so it broke *every* subcommand, not just attach.
  - socket.zig: sessionExists() called Dir.statFile() -> statx.

Both now use fd/at-based stat instead:

  - LogSystem.init() uses posix.fstat(file.handle).
  - sessionExists() uses posix.fstatatZ() + S.ISSOCK().

Because zmx links musl, these resolve to SYS_fstat / SYS_fstatat (musl on x86_64 skips statx entirely), which are available on 4.4. Verified by disassembling the release binary: no reachable statx call remains on the attach path (the only residual references are the DWARF stack-trace unwinder and sendFile fast-paths, neither of which zmx exercises).

Fixes https://github.com/neurosnap/zmx/issues/186