### PR TITLE
Add the ability to disable the detach key with ZMX_NO_DETACH_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ zig build -Doptimize=ReleaseSafe --prefix ~/.local
 ## usage
 
 > [!IMPORTANT]
-> We recommend closing the terminal window to detach from the session but you can also press `ctrl+\` or run `zmx detach`.
+> We recommend closing the terminal window to detach from the session but you can also press `ctrl+\` or run `zmx detach`. If you need `ctrl+\` for something else (e.g. vim's `ctrl+\ ctrl+n` to escape its own `:terminal`), set `ZMX_NO_DETACH_KEY` to disable the shortcut and rely on `zmx detach` or closing the window instead.
 
 Run `zmx help` for more information on usage, with examples.
 

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -63,6 +63,8 @@ pub fn clientLoop(client_sock_fd: i32) !ClientResult {
     _ = try lib_posix.fcntl(stdin_fd, lib_posix.F.SETFL, stdin_orig_flags | lib_posix.O_NONBLOCK);
     defer _ = lib_posix.fcntl(stdin_fd, lib_posix.F.SETFL, stdin_orig_flags) catch {};
 
+    const detach_key_disabled = util.isDetachKeyDisabled();
+
     while (true) {
         poll_fds.clearRetainingCapacity();
 
@@ -113,7 +115,7 @@ pub fn clientLoop(client_sock_fd: i32) !ClientResult {
             if (n_opt) |n| {
                 if (n > 0) {
                     // Check for detach sequences (ctrl+\ as first byte or Kitty escape sequence)
-                    if (util.isCtrlBackslash(buf[0..n])) {
+                    if (!detach_key_disabled and util.isCtrlBackslash(buf[0..n])) {
                         std.log.info("detach key detected", .{});
                         try ipc.appendMessage(gpa, &sock_write_buf, .Detach, "");
                     } else {

--- a/src/main.zig
+++ b/src/main.zig
@@ -539,6 +539,7 @@ fn help(io: std.Io) !void {
         \\  ZMX_SESSION_PREFIX   Prefix added to all session names
         \\  ZMX_DIR_MODE         Sets mode for socket and log directories (octal, defaults to 0750)
         \\  ZMX_LOG_MODE         Sets mode for log files (octal, defaults to 0640)
+        \\  ZMX_NO_DETACH_KEY    Disables the ctrl+\ detach shortcut (set to any value)
         \\
     ;
     var buf: [8192]u8 = undefined;

--- a/src/util.zig
+++ b/src/util.zig
@@ -2,7 +2,9 @@ const std = @import("std");
 const ghostty_vt = @import("ghostty-vt");
 const ipc = @import("ipc.zig");
 const socket = @import("socket.zig");
+const cross = @import("cross.zig");
 const label = @import("label.zig");
+const lib_posix = @import("posix.zig");
 const testing = std.testing;
 
 pub const SessionEntry = struct {
@@ -465,6 +467,13 @@ fn modifyOtherMatches(buf: []const u8, expected_key: u32, expected_mods: u32) bo
 
     // 6. Expect '~' terminator.
     return pos < buf.len and buf[pos] == '~';
+}
+
+/// Returns true when the user has opted out of the ctrl+\ detach shortcut
+/// via ZMX_NO_DETACH_KEY, e.g. to free up ctrl+\ for an inner program
+/// like vim, which uses ctrl+\ ctrl+n to escape its own terminal mode.
+pub fn isDetachKeyDisabled() bool {
+    return lib_posix.getenv("ZMX_NO_DETACH_KEY") != null;
 }
 
 /// Detects vt100 or kitty keyboard protocol escape sequence for up arrow.
@@ -1181,6 +1190,15 @@ test "isCtrlBackslash xterm modifyOtherKeys" {
     try expect(!isCtrlBackslash("\x1b[27;5"));
     try expect(!isCtrlBackslash("\x1b[27;5;"));
     try expect(!isCtrlBackslash("\x1b[27;5;92"));
+}
+
+test "isDetachKeyDisabled" {
+    _ = cross.c.unsetenv("ZMX_NO_DETACH_KEY");
+    try testing.expect(!isDetachKeyDisabled());
+
+    _ = cross.c.setenv("ZMX_NO_DETACH_KEY", "1", 1);
+    defer _ = cross.c.unsetenv("ZMX_NO_DETACH_KEY");
+    try testing.expect(isDetachKeyDisabled());
 }
 
 test "serializeTerminalState excludes synchronized output replay" {


### PR DESCRIPTION
I use ctrl+\ ctrl+n in vim to escape its integrated terminal - this doesn't play nice with zmx.

This PR adds `ZMX_NO_DETACH_KEY` which can be set to disable zmx's `ctrl+\` key handling.

I tested this on `linux-x86_64` with Ghostty.