### PR TITLE
docs: add mise install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@
 brew install neurosnap/tap/zmx
 ```
 
+### mise-en-place
+
+``` bash
+mise use zmx
+```
+
 ### packages (unofficial)
 
 - [Alpine Linux](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/zmx)


### PR DESCRIPTION
Once [mise 2026.7.8](https://github.com/jdx/mise/pull/11020) is released, you can install zmx with mise