### PR TITLE
docs: add zmx-picker to community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,3 +465,4 @@ abduco provides session management (i.e. it allows programs to be run independen
 - [pi-zmx](https://github.com/deevus/pi-zmx) -- [pi](https://pi.dev) extension for zmx.
 - [zsm](https://github.com/mdsakalu/zmx-session-manager) -- TUI session manager for zmx. List, preview, filter, and kill sessions from an interactive terminal UI.
 - [zmosh](https://github.com/mmonad/zmosh) -- A fork of zmx that adds encrypted UDP auto-reconnect for remote sessions (like mosh).
+- [zmx-picker](https://github.com/EarthmanMuons/zmx-picker) -- fzf-based session picker and project launcher. Jump to a running zmx session or start one inside any of your git/jj repos.


### PR DESCRIPTION
It provides `zp`, an fzf-based session picker and project launcher: jump to a running zmx session with scrollback previews, or start a numbered session inside any of your git/jj repositories. It follows zmx conventions where they exist, honoring `ZMX_SESSION_PREFIX` and marking the current session the same way `zmx list` does.

It grew out of the session picker example in the README and @deanobarnett's setup shared in https://github.com/neurosnap/zmx/issues/91#issuecomment-4183106602, packaged up with previews, multi-select kill, jj support, and a test suite.

Quick try:

    brew install EarthmanMuons/tap/zmx-picker

Happy to adjust wording or placement.