### PR TITLE
fix(send): avoid taking client leadership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Use spec: https://common-changelog.org/
 - `zmx run` will now detect heredocs and add the completion marker to a newline
 - Race between `zmx kill X; zmx run X`
 - Improved claim leader detection
+- `zmx send` no longer claims client leadership or triggers a resize probe
 - Improved `ctrl+\` key detection
 - Support for linux kernel < 4.11 by avoiding statx calls
 

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -22,8 +22,9 @@ pub const Tag = enum(u8) {
     LabelSet = 15,
     LabelClear = 16,
     LabelData = 17,
+    Send = 18,
     // Non-exhaustive: this enum comes off the wire via bytesToValue and
-    // @enumFromInt, so out-of-range values (14-255) are representable
+    // @enumFromInt, so out-of-range values (19-255) are representable
     // rather than UB. Switches must handle `_` (unknown tag).
     _,
 };
@@ -306,6 +307,7 @@ test "Tag wire values are frozen" {
         .{ Tag.Run, 9 },       .{ Tag.Ack, 10 },          .{ Tag.Switch, 11 },
         .{ Tag.Write, 12 },    .{ Tag.TaskComplete, 13 }, .{ Tag.LabelGet, 14 },
         .{ Tag.LabelSet, 15 }, .{ Tag.LabelClear, 16 },   .{ Tag.LabelData, 17 },
+        .{ Tag.Send, 18 },
     }) |p| try std.testing.expectEqual(@as(u8, p[1]), @intFromEnum(p[0]));
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -287,7 +287,7 @@ pub fn main() !void {
             error.NameTooLong => return socket.printSessionNameTooLong(sesh, cfg.socket_dir),
             error.OutOfMemory => return err,
         };
-        return send(&cfg, sesh, socket_path, text_parts.items, .Input);
+        return send(&cfg, sesh, socket_path, text_parts.items, .Send);
     } else if (std.mem.eql(u8, cmd, "print") or std.mem.eql(u8, cmd, "p")) {
         const session_name = args.next() orelse "";
         if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
@@ -1046,6 +1046,11 @@ const Daemon = struct {
         }
     }
 
+    /// Queue input from `zmx send` without changing interactive client leadership.
+    pub fn handleSend(self: *Daemon, payload: []const u8) void {
+        self.queuePtyInput(payload);
+    }
+
     pub fn handleSwitch(self: *Daemon, session_name: []const u8) !void {
         for (self.clients.items) |client| {
             if (self.leader_client_fd == client.socket_fd) {
@@ -1370,6 +1375,27 @@ const Daemon = struct {
         );
     }
 };
+
+test "send queues PTY input without changing leader" {
+    const alloc = std.testing.allocator;
+    var daemon = Daemon{
+        .cfg = undefined,
+        .alloc = alloc,
+        .clients = .empty,
+        .leader_client_fd = 42,
+        .session_name = "test",
+        .socket_path = "",
+        .running = true,
+        .pid = 0,
+        .created_at = 0,
+    };
+    defer daemon.pty_write_buf.deinit(alloc);
+
+    daemon.handleSend("hello");
+
+    try std.testing.expectEqual(@as(?i32, 42), daemon.leader_client_fd);
+    try std.testing.expectEqualStrings("hello", daemon.pty_write_buf.items);
+}
 
 fn printVersion(cfg: *Cfg) !void {
     var buf: [256]u8 = undefined;
@@ -3042,6 +3068,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
                 while (client.read_buf.next()) |msg| {
                     switch (msg.header.tag) {
                         .Input => try daemon.handleInput(client, msg.payload),
+                        .Send => daemon.handleSend(msg.payload),
                         .Output => try daemon.handleOutput(msg.payload, &vt_stream),
                         .Init => try daemon.handleInit(client, pty_fd, &term, msg.payload),
                         .Switch => try daemon.handleSwitch(msg.payload),


### PR DESCRIPTION
## Summary

- Add a dedicated `.Send` IPC tag for `zmx send`.
- Queue send input without changing the active leader or requesting a resize.
- Keep `.Input` behavior unchanged for attached clients.

Fixes #201.

## Tag name

I used `.Send` for now. It maps directly to `zmx send` and keeps `.Input` for attached clients, but I'm very open to renaming it. `Inject` was the other obvious option, though it felt a little odd.

## Tests

- `zig build test`
- `bats test` (39/39)

Older daemons ignore the new tag, so existing sessions need to be restarted after upgrading for `send` to work.
