### PR TITLE
build: canonicalize ghostty dep URL

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const build_zig_zon = @import("build.zig.zon");
 
 const linux_targets: []const std.Target.Query = &.{
     .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .musl },
@@ -15,11 +16,11 @@ pub fn build(b: *std.Build) void {
     const is_macos = target.result.os.tag == .macos;
     const optimize = b.standardOptimizeOption(.{});
     const version = b.option([]const u8, "version", "Version string for release") orelse
-        @as([]const u8, @import("build.zig.zon").version);
+        @as([]const u8, build_zig_zon.version);
 
     const options = b.addOptions();
     options.addOption([]const u8, "version", version);
-    const ghostty_ver = @import("build.zig.zon").dependencies.ghostty.hash;
+    const ghostty_ver = build_zig_zon.dependencies.ghostty.hash;
     options.addOption([]const u8, "ghostty_version", ghostty_ver);
 
     const exe_mod = b.createModule(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .ghostty = .{
-            .url = "git+https://github.com/ghostty-org/ghostty.git/?ref=HEAD#30e1f3bb8c3d2949e9ae4aefc1c2b76142569cfb",
+            .url = "git+https://github.com/ghostty-org/ghostty#30e1f3bb8c3d2949e9ae4aefc1c2b76142569cfb",
             .hash = "ghostty-1.3.2-dev-5UdBC5gHIgWG-_Voonf5F76Vt2I2KljI5lIuvI-7eyBI",
         },
     },


### PR DESCRIPTION
While here, only import build.zig.zon once in build.zig.