### PR TITLE
Keep `zmx list` output well-formed; enforce the label charset in the daemon

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -703,6 +703,17 @@ const Daemon = struct {
 
         var kvs = label.LabelIterator.init(labels);
         while (kvs.next()) |kv| {
+            // The CLI validates before sending, but the socket accepts messages from
+            // any writer, and stored labels are printed raw into `zmx list` lines —
+            // a value carrying a tab or newline would forge extra fields or whole
+            // rows there. Enforce the same charset the CLI does, per pair; a bad pair
+            // is dropped (logged) rather than failing the whole Ack a well-behaved
+            // client is waiting on. (`assertLabel` accepts an empty value — that's the
+            // remove form.)
+            label.assertLabel(kv.key, kv.value) catch |err| {
+                std.log.warn("rejecting label pair over IPC key={s} err={s}", .{ kv.key, @errorName(err) });
+                continue;
+            };
             if (kv.value.len == 0) {
                 if (self.labels.fetchRemove(kv.key)) |existing| {
                     self.alloc.free(existing.key);

--- a/src/util.zig
+++ b/src/util.zig
@@ -813,11 +813,18 @@ pub fn writeSessionLine(
         session.clients_len.?,
         session.created_at,
     });
+    // start_dir and cmd are attacker-chosen at session creation (`zmx attach
+    // name -- <cmd>` from any dir) and this format is line/tab-delimited: an
+    // embedded separator would forge extra fields or whole extra rows for
+    // parsers of `zmx list`. Display-only fields, so separators just fold to
+    // spaces. (Labels are charset-validated when set, so they can't.)
     if (session.cwd) |cwd| {
-        try writer.print("\tstart_dir={s}", .{cwd});
+        try writer.print("\tstart_dir=", .{});
+        try writeFieldSafe(writer, cwd);
     }
     if (session.cmd) |cmd| {
-        try writer.print("\tcmd={s}", .{cmd});
+        try writer.print("\tcmd=", .{});
+        try writeFieldSafe(writer, cmd);
     }
     if (session.task_ended_at) |ended_at| {
         if (ended_at > 0) {
@@ -835,6 +842,37 @@ pub fn writeSessionLine(
         }
     }
     try writer.print("\n", .{});
+}
+
+/// Print a free-form field value with `zmx list` separators (tab, newline,
+/// carriage return) folded to spaces so it can't break out of its field/row.
+fn writeFieldSafe(writer: *std.Io.Writer, value: []const u8) !void {
+    for (value) |c| {
+        try writer.writeByte(if (c == '\t' or c == '\n' or c == '\r') ' ' else c);
+    }
+}
+
+test "writeSessionLine folds separators in cmd/start_dir so a row can't be forged" {
+    var builder: std.Io.Writer.Allocating = .init(testing.allocator);
+    defer builder.deinit();
+    const session = SessionEntry{
+        .name = "dev",
+        .pid = 1,
+        .clients_len = 0,
+        .is_error = false,
+        .error_name = null,
+        .cmd = "printf 'a\nname=evil\tclients=9\tcreated=1'",
+        .cwd = "/tmp/tab\there",
+        .created_at = 0,
+        .task_ended_at = null,
+        .task_exit_code = null,
+    };
+    try writeSessionLine(&builder.writer, session, false, null);
+    const out = builder.writer.buffered();
+    // Exactly one line, and the injected separators didn't create fields.
+    try testing.expectEqual(@as(usize, 1), std.mem.count(u8, out, "\n"));
+    try testing.expect(std.mem.indexOf(u8, out, "\tclients=9") == null);
+    try testing.expect(std.mem.indexOf(u8, out, "start_dir=/tmp/tab here") != null);
 }
 
 test "writeSessionLine formats output for current session and short output" {

--- a/test/labels.bats
+++ b/test/labels.bats
@@ -97,3 +97,48 @@ load test_helper
   run env -u ZMX_SESSION "$ZMX" get
   [[ "$output" == *"SessionNameRequired"* ]]
 }
+
+# ============================================================================
+# Daemon-side validation (IPC bypass)
+# ============================================================================
+# The CLI validates the label charset before sending, but the daemon socket
+# accepts messages from any writer. A value carrying \t or \n printed raw into
+# `zmx list` forges extra fields or whole extra rows for anything parsing
+# that output. The daemon must enforce the charset itself.
+
+@test "daemon rejects a raw-IPC label whose value carries separators" {
+  command -v python3 >/dev/null || skip "python3 required to craft raw IPC"
+  "$ZMX" run test-rawlbl -d sleep 30
+  wait_for_session test-rawlbl
+  "$ZMX" set test-rawlbl legit=ok   # a valid pair via the CLI, for contrast
+
+  # Craft a LabelSet (tag 15) frame directly on the session socket: header is
+  # packed {u8 tag, u32 len} sized 8, little-endian. Payload smuggles a tab
+  # and a newline — a forged field and a forged whole row.
+  run python3 - "$ZMX_DIR" <<'PY'
+import socket, struct, sys, os
+sock_dir = sys.argv[1]
+path = os.path.join(sock_dir, "test-rawlbl")
+s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+s.connect(path)
+payload = b"evil=x\tclients=9\nname=forged\tpid=1\tclients=0\tcreated=1"
+s.sendall(struct.pack("<BIxxx", 15, len(payload)) + payload)
+s.settimeout(1.0)
+try:
+    s.recv(64)
+except Exception:
+    pass
+s.close()
+PY
+  [ "$status" -eq 0 ]
+
+  # Nothing forged: one row for the session, real client count, no evil key.
+  run "$ZMX" list
+  [ "$status" -eq 0 ]
+  [[ "$(printf '%s\n' "$output" | grep -c 'name=test-rawlbl')" -eq 1 ]]
+  [[ "$output" != *"name=forged"* ]]
+  [[ "$output" != *"evil="* ]]
+  # The valid CLI-set pair survives; the rejected one didn't wedge the daemon.
+  run "$ZMX" get test-rawlbl
+  [[ "$output" == *"legit=ok"* ]]
+}


### PR DESCRIPTION
`zmx list` prints each session as one line of tab-separated `k=v` fields, so the format has two structural separators — tab between fields, newline between sessions — and no escaping for either. Two of the printed values are free-form and can legitimately contain those characters: `cmd` and `start_dir` are whatever the session was created with (a `-- bash -c $'…\n…'` argument, an unusually named directory). One such session makes the whole listing malformed for anything that parses it — including this repo's own bats helpers.

Separately, the label charset (`[A-Za-z0-9._-]`) is what makes labels safe to print in that format, but it was only checked in the `zmx set` CLI. The daemon's `LabelSet` handler stored whatever bytes arrived, so any other client speaking the socket protocol (a script, a different client version) could store labels that `zmx get`/`zmx list` then can't faithfully print. The check belongs where the labels are stored.

Changes:
- `writeSessionLine` folds tab/newline/CR to spaces in `start_dir` and `cmd` before printing. These are display fields, so the lossy fold costs nothing and the session still lists as one well-formed line.
- `handleLabelSet` runs the same `assertLabel` charset check the CLI does; a pair failing it is dropped with a log line while the client still gets its Ack, so the invariant holds for all clients rather than just the bundled CLI.

Tests: a unit test that separator characters in `cmd`/`start_dir` can't split the line into extra fields or rows, and a bats test that sends a `LabelSet` frame directly over the session socket (the CLI would reject the input first) and confirms the out-of-charset pair isn't stored while a valid one is.