### PR TITLE
fix: attach hang against pre-0.7.0 daemons

### DIFF
--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -112,6 +112,23 @@ pub fn appendMessage(
     }
 }
 
+/// Pre-0.7.0 daemons expect a 4-byte Init/Resize payload (rows+cols, no
+/// pixel size) and silently drop the 8-byte form, hanging `zmx attach`
+/// against a running old daemon (#211). Append both encodings: every daemon
+/// drops the length it doesn't expect and processes the other exactly once.
+pub const LEGACY_RESIZE_LEN = 4;
+
+pub fn appendSizeMessage(
+    alloc: std.mem.Allocator,
+    list: *std.ArrayList(u8),
+    tag: Tag,
+    size: Resize,
+) !void {
+    const bytes = std.mem.asBytes(&size);
+    try appendMessage(alloc, list, tag, bytes);
+    try appendMessage(alloc, list, tag, bytes[0..LEGACY_RESIZE_LEN]);
+}
+
 fn writeAll(fd: i32, data: []const u8) !void {
     var index: usize = 0;
     while (index < data.len) {
@@ -340,6 +357,30 @@ pub fn roundTripForTag(
         }
     }
     return error.Unexpected;
+}
+
+test "appendSizeMessage emits current and legacy encodings" {
+    const alloc = std.testing.allocator;
+    var list = try std.ArrayList(u8).initCapacity(alloc, 64);
+    defer list.deinit(alloc);
+
+    const size = Resize{ .rows = 45, .cols = 170, .xpixel = 900, .ypixel = 1800 };
+    try appendSizeMessage(alloc, &list, .Init, size);
+
+    const h1 = std.mem.bytesToValue(Header, list.items[0..@sizeOf(Header)]);
+    try std.testing.expectEqual(Tag.Init, h1.tag);
+    try std.testing.expectEqual(@as(u32, @sizeOf(Resize)), h1.len);
+    const p1 = list.items[@sizeOf(Header)..][0..@sizeOf(Resize)];
+    try std.testing.expectEqual(size, std.mem.bytesToValue(Resize, p1));
+
+    const off2 = @sizeOf(Header) + @sizeOf(Resize);
+    const h2 = std.mem.bytesToValue(Header, list.items[off2..][0..@sizeOf(Header)]);
+    try std.testing.expectEqual(Tag.Init, h2.tag);
+    try std.testing.expectEqual(@as(u32, LEGACY_RESIZE_LEN), h2.len);
+    // Legacy payload is the rows+cols prefix of the current encoding.
+    const p2 = list.items[off2 + @sizeOf(Header) ..][0..LEGACY_RESIZE_LEN];
+    try std.testing.expectEqualSlices(u8, p1[0..LEGACY_RESIZE_LEN], p2);
+    try std.testing.expectEqual(off2 + @sizeOf(Header) + LEGACY_RESIZE_LEN, list.items.len);
 }
 
 test "zeroed Info has no stack garbage in wire bytes" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -2692,7 +2692,7 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
 
     // Send init message with terminal size (buffered)
     const size = ipc.getTerminalSize(lib_posix.STDOUT_FILENO);
-    try ipc.appendMessage(alloc, &sock_write_buf, .Init, std.mem.asBytes(&size));
+    try ipc.appendSizeMessage(alloc, &sock_write_buf, .Init, size);
 
     var poll_fds = try std.ArrayList(lib_posix.pollfd).initCapacity(alloc, 4);
     defer poll_fds.deinit(alloc);
@@ -2747,7 +2747,7 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
         if (poll_fds.items[2].revents & lib_posix.POLL.IN != 0) {
             drainSignalPipe();
             const next_size = ipc.getTerminalSize(lib_posix.STDOUT_FILENO);
-            try ipc.appendMessage(alloc, &sock_write_buf, .Resize, std.mem.asBytes(&next_size));
+            try ipc.appendSizeMessage(alloc, &sock_write_buf, .Resize, next_size);
         }
 
         // Handle stdin -> socket (Input)
@@ -2803,12 +2803,7 @@ fn clientLoop(client_sock_fd: i32) !ClientResult {
                         // daemon is asking for the client's window size usually in response
                         // to this client being set as leader.
                         const next_size = ipc.getTerminalSize(lib_posix.STDOUT_FILENO);
-                        try ipc.appendMessage(
-                            alloc,
-                            &sock_write_buf,
-                            .Resize,
-                            std.mem.asBytes(&next_size),
-                        );
+                        try ipc.appendSizeMessage(alloc, &sock_write_buf, .Resize, next_size);
                     },
                     .Switch => {
                         std.log.info("switch session", .{});

--- a/src/main.zig
+++ b/src/main.zig
@@ -110,7 +110,7 @@ pub fn main(init: std.process.Init) !void {
 
     const log_path = try std.fs.path.join(gpa, &.{ cfg.log_dir, "zmx.log" });
     defer gpa.free(log_path);
-    const log_mode = std.Io.File.Permissions.fromMode(cfg.log_mode);
+    const log_mode = std.Io.File.Permissions.fromMode(@intCast(cfg.log_mode));
     try log_system.init(gpa, io, log_path, log_mode);
     defer log_system.deinit();
 
@@ -985,7 +985,7 @@ const Daemon = struct {
                     &.{ self.cfg.log_dir, session_log_name },
                 );
                 defer self.alloc.free(session_log_path);
-                const log_mode = std.Io.File.Permissions.fromMode(self.cfg.log_mode);
+                const log_mode = std.Io.File.Permissions.fromMode(@intCast(self.cfg.log_mode));
                 try log_system.init(self.alloc, self.io, session_log_path, log_mode);
 
                 // If spawnPty fails, clean up here. Once it succeeds,
@@ -3149,7 +3149,7 @@ fn daemonLoop(daemon: *Daemon, server_sock_fd: i32, pty_fd: i32) !void {
     }
 }
 
-fn wakeSignalPipe(_: std.os.linux.SIG, _: *const lib_posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
+fn wakeSignalPipe(_: lib_posix.SIG, _: *const lib_posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
     const saved = std.c._errno().*;
     _ = std.c.write(sig_pipe[1], "x", 1);
     std.c._errno().* = saved;


### PR DESCRIPTION
Fixes #211

## Root cause

7381df3 (released in 0.7.0) grew the `ipc.Resize` payload from 4 to 8 bytes by adding `xpixel`/`ypixel`. Daemons on both sides of that change validate `Init`/`Resize` strictly:

```zig
if (payload.len != @sizeOf(ipc.Resize)) return;
```

so a pre-0.7.0 daemon silently drops the new client's 8-byte `Init`, never registers the client, and never replays scrollback — `zmx attach` hangs on a blank screen with no error. Everything else on the wire (`Input`, `Output`, `Detach`, `Switch`, header layout, tag values) is unchanged, so attach compatibility is fully recoverable.

## Fix

The client now sends every `Init`/`Resize` twice: the current 8-byte encoding followed by its legacy 4-byte prefix (rows+cols) — see `ipc.appendSizeMessage`. Because every daemon generation length-checks the payload, each daemon drops the encoding it doesn't expect and processes the other exactly once:

- pre-0.7.0 daemon: drops 8-byte, handles 4-byte → attach works again
- 0.7.0+ daemon: handles 8-byte, drops 4-byte → behavior unchanged, no double replay

Compared to a version probe (e.g. the `LabelGet` timeout heuristic `zmx get` uses), dual-send is deterministic: no extra round-trip, and no risk of a slow machine misclassifying a new daemon and hanging again.

The first commit fixes two unrelated darwin build errors introduced by the zig 0.16 upgrade (`mode_t` is `u16` on macOS; `wakeSignalPipe` was typed with `std.os.linux.SIG` instead of `posix.SIG`).

## Testing

- Reproduced against a real 0.6.0 daemon still running from before my brew upgrade: stock 0.7.0 client captures 9 bytes (clear-screen + reset only, blank hang); patched client receives the full ~70 KB scrollback replay and detaches cleanly.
- Verified against a freshly spawned patched daemon: single replay, no duplication (dropped 4-byte dup confirmed by the existing length check).
- Added a unit test for `appendSizeMessage` wire output; `zig build test` passes.
