### PR TITLE
chore: canonicalize ghostty dep URL again

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,7 +5,7 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ghostty = .{
-            .url = "git+https://github.com/ghostty-org/ghostty.git/#15484b607eb5a518dedf1548247c923b8abaae7c",
+            .url = "git+https://github.com/ghostty-org/ghostty#15484b607eb5a518dedf1548247c923b8abaae7c",
             .hash = "ghostty-1.3.2-dev-5UdBCwfRJAX2W3lpOWUOrkLvsqJckxucSrjECoDjq9kL",
         },
     },


### PR DESCRIPTION
https://github.com/ghostty-org/ghostty.git is a redirect to https://github.com/ghostty-org/ghostty. Note that
https://github.com/ghostty-org/ghostty.git/archive/HASH.tar.gz does NOT exist, but https://github.com/ghostty-org/ghostty/archive/HASH.tar.gz DOES.