### PR TITLE
fix: build on macOS with zig 0.16.0

### DIFF
--- a/src/loop.zig
+++ b/src/loop.zig
@@ -725,7 +725,7 @@ pub const Daemon = struct {
                 fba.allocator(),
                 &.{ self.cfg.log_dir, session_log_name },
             );
-            const log_mode = std.Io.File.Permissions.fromMode(self.cfg.log_mode);
+            const log_mode = std.Io.File.Permissions.fromMode(@intCast(self.cfg.log_mode));
             log.log_system.init(new_io, session_log_path, log_mode) catch {};
         }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -42,7 +42,7 @@ pub fn main(init: std.process.Init) !void {
 
     const log_path = try std.fs.path.join(gpa, &.{ cfg.log_dir, "zmx.log" });
     defer gpa.free(log_path);
-    const log_mode = std.Io.File.Permissions.fromMode(cfg.log_mode);
+    const log_mode = std.Io.File.Permissions.fromMode(@intCast(cfg.log_mode));
     try log.log_system.init(io, log_path, log_mode);
     defer log.log_system.deinit();
 

--- a/src/signal.zig
+++ b/src/signal.zig
@@ -6,7 +6,7 @@ const lib_posix = @import("posix.zig");
 /// never surfaces; the handler writes a byte here and poll() wakes on POLLIN.
 pub var sig_pipe: [2]lib_posix.fd_t = .{ -1, -1 };
 
-pub fn wakeSignalPipe(_: std.os.linux.SIG, _: *const lib_posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
+pub fn wakeSignalPipe(_: lib_posix.SIG, _: *const lib_posix.siginfo_t, _: ?*anyopaque) callconv(.c) void {
     const saved = std.c._errno().*;
     _ = std.c.write(sig_pipe[1], "x", 1);
     std.c._errno().* = saved;


### PR DESCRIPTION
`main` does not compile on macOS with zig 0.16.0. Two unrelated type errors:

- `main.zig` / `loop.zig`: `cfg.log_mode` is `u32` but `File.Permissions.fromMode` takes `mode_t`, which is `u16` here. `cfg.zig` already casts for the equivalent `Dir.Permissions` calls.
- `signal.zig`: the wake handler was declared with `std.os.linux.SIG`, which `sigaction` rejects on macOS. `posix.zig` already re-exports `SIG`.

`zig build` and `zig build test` both pass on macOS 15 (aarch64) after these.