### PR TITLE
fix: replay the window title on attach

### DIFF
--- a/src/util.zig
+++ b/src/util.zig
@@ -702,6 +702,16 @@ pub fn serializeTerminalState(alloc: std.mem.Allocator, term: *ghostty_vt.Termin
         return null;
     };
 
+    // The formatter has no title extra and never emits OSC 0/1/2, so the title
+    // has to be replayed separately or an attaching client shows whatever its
+    // terminal defaults to, usually the client process name. OSC 2 does not
+    // move the cursor, so this is safe to append after the content.
+    if (term.getTitle()) |title| {
+        builder.writer.print("\x1b]2;{s}\x07", .{title}) catch |err| {
+            std.log.warn("failed to format title err={s}", .{@errorName(err)});
+        };
+    }
+
     const output = builder.writer.buffered();
     if (output.len == 0) return null;
 
@@ -1189,6 +1199,49 @@ test "serializeTerminalState excludes synchronized output replay" {
     // but NOT synchronized output (DECSET 2026)
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?2004h") != null);
     try testing.expect(std.mem.indexOf(u8, output, "\x1b[?2026h") == null);
+}
+
+test "serializeTerminalState replays the title" {
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var term = try ghostty_vt.Terminal.init(io, alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+
+    stream.nextSlice("\x1b]2;my title\x07");
+    stream.nextSlice("hello");
+
+    const output = serializeTerminalState(alloc, &term) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b]2;my title\x07") != null);
+}
+
+test "serializeTerminalState omits the title when none is set" {
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var term = try ghostty_vt.Terminal.init(io, alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+
+    stream.nextSlice("hello");
+
+    const output = serializeTerminalState(alloc, &term) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b]2;") == null);
 }
 
 fn testCreateTerminal(alloc: std.mem.Allocator, io: std.Io, cols: u16, rows: u16, vt_data: []const u8) !ghostty_vt.Terminal {


### PR DESCRIPTION
Related to #222, which covers title, cwd, and modes. This handles the title case only. The modes case looks fixed already by 266a733; cwd is still open and discussed in #160.

`TerminalFormatter` has no title extra and never emits OSC 0/1/2, so a client attaching to an existing session shows whatever its terminal falls back to, usually the name of the client process, even though `Terminal` already tracks the title. `serializeTerminalState` has the `*Terminal` in hand, so it can replay it alongside the state the formatter already emits.

Verified with an A/B on the same scenario, window geometry pinned so no incidental SIGWINCH could mask the result, and nvim left running so nothing else would re-emit a title:

| build | title after detach/reattach |
|---|---|
| this patch | `nvim ~/.dotfiles (master)` |
| unpatched | `attach` |

The running-program case is the one that motivated this. A shell reprints its title at the next prompt, so the window looks correct again quickly, but a long running program does not reprint, and the wrong title stays for as long as it runs. Handling it here also avoids needing a shell-side workaround, which only helps the shell that implements it and not other programs that set titles.

Two tests added: one that the title is replayed, one that no stray OSC 2 is emitted when no title is set.

Note that `main` does not currently compile on macOS with zig 0.16.0 for unrelated reasons (#223), so I verified this on top of those fixes.