### PR TITLE
fix(log): make PTY input logging opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ This is particularly useful when running `zmx` as a system service with a shared
 
 We store global logs for cli commands in `{log_dir}/zmx.log`. We store session-specific logs in `{log_dir}/{session_name}.log`. Right now they are enabled by default and cannot be disabled. The idea here is to help with initial development until we reach a stable state.
 
+These logs never contain terminal output or PTY input. Setting `ZMX_LOG_INPUT` adds a hex dump of every byte sent to the PTY, which is useful when debugging key handling but records keystrokes verbatim, including anything typed at a password prompt. Leave it unset unless you are debugging, and delete the session log afterwards.
+
 The log directory is resolved in this order:
 
 1. `ZMX_DIR/logs` if `ZMX_DIR` is set

--- a/src/cfg.zig
+++ b/src/cfg.zig
@@ -12,6 +12,10 @@ log_dir: []const u8,
 max_scrollback_lines: usize = 2_000, // same default as tmux
 dir_mode: u32 = 0o750,
 log_mode: u32 = 0o640,
+/// Hex-dump every byte queued for the PTY into the session log. This is
+/// keystroke capture -- it records passwords typed at any prompt -- so it
+/// stays off unless ZMX_LOG_INPUT is set.
+log_input: bool = false,
 
 pub fn init(alloc: std.mem.Allocator, io: std.Io) !Cfg {
     const socket_dir = try socketDir(alloc);
@@ -34,6 +38,7 @@ pub fn init(alloc: std.mem.Allocator, io: std.Io) !Cfg {
         .log_dir = log_dir,
         .dir_mode = dir_mode,
         .log_mode = log_mode,
+        .log_input = lib_posix.getenv("ZMX_LOG_INPUT") != null,
     };
 
     try cfg.mkdir(io);

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -557,6 +557,9 @@ pub const Daemon = struct {
     task_ended_at: ?u64 = null, // timestamp when task exited
     pty_fd: i32 = -1, // set by daemonLoop so handleRun can probe the foreground process
     shell: []const u8 = "/bin/sh",
+    /// Copied from Cfg at init: fixed for the daemon's lifetime, and read on
+    /// the PTY write path where chasing the Cfg pointer buys nothing.
+    log_input: bool = false,
 
     /// Create a Daemon. Caller is responsible for freeing all variables passed
     /// into the init fn.
@@ -566,6 +569,7 @@ pub const Daemon = struct {
             .session_name = sesh_name,
             .socket_path = socket_path,
             .created_at = @intCast(std.Io.Timestamp.now(io, .real).toSeconds()),
+            .log_input = cfg.log_input,
         };
     }
 
@@ -786,17 +790,19 @@ pub const Daemon = struct {
             );
             return;
         }
-        std.log.debug("buffering pty input data={x}", .{data});
         self.pty_write_buf.appendSlice(gpa, data) catch |err| {
             std.log.warn(
                 "pty input dropped {d} bytes: {s}",
                 .{ data.len, @errorName(err) },
             );
+            return;
         };
+        // Everything headed for the PTY funnels through here, so this single
+        // site covers interactive keystrokes, `send`, `run`, and `write`.
+        if (self.log_input) std.log.debug("buffering pty input data={x}", .{data});
     }
 
     pub fn handleInput(self: *Daemon, gpa: std.mem.Allocator, client: *Client, payload: []const u8) !void {
-        std.log.debug("buffering pty input data={x}", .{payload});
         // client is leader, send entire payload (ansi escape codes + text)
         if (self.leader_client_fd == client.socket_fd) {
             self.queuePtyInput(gpa, payload);
@@ -1136,10 +1142,7 @@ pub const Daemon = struct {
         try ipc.appendMessage(gpa, &client.write_buf, .Ack, "");
         client.has_pending_output = true;
         self.has_had_client = true;
-        std.log.debug(
-            "write command len={d} file_path={s}",
-            .{ file_content.len, file_path },
-        );
+        std.log.debug("write command len={d}", .{file_content.len});
     }
 
     fn handleLabelGet(self: *Daemon, gpa: std.mem.Allocator, client: *Client) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -539,6 +539,8 @@ fn help(io: std.Io) !void {
         \\  ZMX_SESSION_PREFIX   Prefix added to all session names
         \\  ZMX_DIR_MODE         Sets mode for socket and log directories (octal, defaults to 0750)
         \\  ZMX_LOG_MODE         Sets mode for log files (octal, defaults to 0640)
+        \\  ZMX_LOG_INPUT        Hex-dump PTY input to the session log (records
+        \\                       keystrokes, including passwords; off by default)
         \\
     ;
     var buf: [8192]u8 = undefined;

--- a/test/logging.bats
+++ b/test/logging.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# PTY input logging tests for zmx.
+#
+# The session log lives on disk for the lifetime of the session. Anything
+# typed at a password prompt reaches the daemon as PTY input, so the hex dump
+# has to stay off unless the operator asks for it.
+
+load test_helper
+
+# ZMX_DIR is isolated per test, and logs land in $ZMX_DIR/logs.
+session_log() {
+  echo "$ZMX_DIR/logs/$1.log"
+}
+
+# "hunter2" as the daemon would hex-dump it.
+SECRET_HEX='68756e74657232'
+
+@test "log-input: PTY input is not logged by default" {
+  run "$ZMX" run log-default -d cat
+  [ "$status" -eq 0 ]
+  wait_for_session log-default
+
+  "$ZMX" send log-default 'hunter2'
+  # The PTY echoes what it received, so this also proves the daemon queued it.
+  wait_for_output log-default hunter2
+
+  local log
+  log="$(session_log log-default)"
+  [ -f "$log" ]
+  run grep -F 'hunter2' "$log"
+  [ "$status" -ne 0 ]
+  run grep -Fi "$SECRET_HEX" "$log"
+  [ "$status" -ne 0 ]
+}
+
+@test "log-input: ZMX_LOG_INPUT opts the session in" {
+  ZMX_LOG_INPUT=1 run "$ZMX" run log-optin -d cat
+  [ "$status" -eq 0 ]
+  wait_for_session log-optin
+
+  # The sending client does not set ZMX_LOG_INPUT: policy belongs to the
+  # daemon that owns the session, fixed when the session was created.
+  "$ZMX" send log-optin 'hunter2'
+  wait_for_output log-optin hunter2
+
+  run grep -Fi "$SECRET_HEX" "$(session_log log-optin)"
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
In an LLM-aided security review of zmx for my own use, the logging of input keystrokes to `{log_dir}/{session}.log` was flagged, since it means tokens, passwords etc. entered during a session gets logged and left in these files even when not echoed on screen.

This PR turns off the input keystroke logging unless environment variable ZMX_LOG_INPUT is defined.

(Apologies if you prefer not getting LLM-aided PRs; if so, just close this)