### PR TITLE
fix(fs): make configured modes authoritative, private by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,10 +416,10 @@ Each session gets its own unix socket file. The default location depends on your
 
 You can configure the permissions for the socket directory and log files using the following environment variables:
 
-- `ZMX_DIR_MODE` => sets the mode for the socket and log directories (octal, defaults to `0750`)
-- `ZMX_LOG_MODE` => sets the mode for the log files (octal, defaults to `0640`)
+- `ZMX_DIR_MODE` => sets the mode for the socket and log directories (octal, defaults to `0700`)
+- `ZMX_LOG_MODE` => sets the mode for the log files (octal, defaults to `0600`)
 
-This is particularly useful when running `zmx` as a system service with a shared group. For example, setting `ZMX_DIR_MODE=0770` and `ZMX_LOG_MODE=0660` allows group members to attach to the session.
+Session sockets are created with `ZMX_DIR_MODE` minus its execute bits, so they default to `0600` and follow the directory when you widen it. This is particularly useful when running `zmx` as a system service with a shared group. For example, setting `ZMX_DIR_MODE=0770` and `ZMX_LOG_MODE=0660` allows group members to attach to the session.
 
 ## debugging
 

--- a/src/cfg.zig
+++ b/src/cfg.zig
@@ -10,8 +10,8 @@ const cross = @import("cross.zig");
 socket_dir: []const u8,
 log_dir: []const u8,
 max_scrollback_lines: usize = 2_000, // same default as tmux
-dir_mode: u32 = 0o750,
-log_mode: u32 = 0o640,
+dir_mode: u32 = 0o700,
+log_mode: u32 = 0o600,
 
 pub fn init(alloc: std.mem.Allocator, io: std.Io) !Cfg {
     const socket_dir = try socketDir(alloc);
@@ -20,14 +20,14 @@ pub fn init(alloc: std.mem.Allocator, io: std.Io) !Cfg {
     errdefer alloc.free(log_dir);
 
     const dir_mode = if (lib_posix.getenv("ZMX_DIR_MODE")) |m|
-        std.fmt.parseInt(u32, m, 8) catch 0o750
+        std.fmt.parseInt(u32, m, 8) catch 0o700
     else
-        0o750;
+        0o700;
 
     const log_mode = if (lib_posix.getenv("ZMX_LOG_MODE")) |m|
-        std.fmt.parseInt(u32, m, 8) catch 0o640
+        std.fmt.parseInt(u32, m, 8) catch 0o600
     else
-        0o640;
+        0o600;
 
     var cfg = Cfg{
         .socket_dir = socket_dir,
@@ -77,7 +77,16 @@ pub fn deinit(self: *Cfg, alloc: std.mem.Allocator) void {
     if (self.log_dir.len > 0) alloc.free(self.log_dir);
 }
 
+/// Socket permissions mirror the directory's, minus the execute bits that
+/// mean nothing on a socket.
+pub fn socketMode(self: *const Cfg) u32 {
+    return self.dir_mode & 0o666;
+}
+
 pub fn mkdir(self: *Cfg, io: std.Io) !void {
+    // mkdir(2) applies mode & ~umask, so adjust umask here
+    const old_umask = cross.c.umask(@intCast((~self.dir_mode) & 0o777));
+    defer _ = cross.c.umask(old_umask);
     const sock_perms = std.Io.Dir.Permissions.fromMode(@intCast(self.dir_mode));
     try mkdirAll(io, self.socket_dir, sock_perms);
     const log_perms = std.Io.Dir.Permissions.fromMode(@intCast(self.dir_mode));
@@ -110,8 +119,9 @@ test "Cfg.init uses default modes when env vars are not set" {
     var cfg = try Cfg.init(alloc, std.testing.io);
     defer cfg.deinit(alloc);
 
-    try std.testing.expectEqual(@as(u32, 0o750), cfg.dir_mode);
-    try std.testing.expectEqual(@as(u32, 0o640), cfg.log_mode);
+    try std.testing.expectEqual(@as(u32, 0o700), cfg.dir_mode);
+    try std.testing.expectEqual(@as(u32, 0o600), cfg.log_mode);
+    try std.testing.expectEqual(@as(u32, 0o600), cfg.socketMode());
 }
 
 test "Cfg.init uses custom modes from env vars" {
@@ -130,4 +140,6 @@ test "Cfg.init uses custom modes from env vars" {
 
     try std.testing.expectEqual(@as(u32, 0o770), cfg.dir_mode);
     try std.testing.expectEqual(@as(u32, 0o660), cfg.log_mode);
+    // Shared-group setups still get a group-connectable socket.
+    try std.testing.expectEqual(@as(u32, 0o660), cfg.socketMode());
 }

--- a/src/cross.zig
+++ b/src/cross.zig
@@ -6,18 +6,21 @@ pub const c = switch (builtin.os.tag) {
         @cInclude("sys/ioctl.h"); // ioctl and constants
         @cInclude("termios.h");
         @cInclude("stdlib.h");
+        @cInclude("sys/stat.h"); // umask
         @cInclude("unistd.h");
     }),
     .freebsd => @cImport({
         @cInclude("termios.h"); // ioctl and constants
         @cInclude("libutil.h"); // openpty()
         @cInclude("stdlib.h");
+        @cInclude("sys/stat.h"); // umask
         @cInclude("unistd.h");
     }),
     else => @cImport({
         @cInclude("sys/ioctl.h"); // ioctl and constants
         @cInclude("pty.h");
         @cInclude("stdlib.h");
+        @cInclude("sys/stat.h"); // umask
         @cInclude("unistd.h");
     }),
 };

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -685,6 +685,7 @@ pub const Daemon = struct {
     fn run(self: *Daemon, io: std.Io, dir: std.Io.Dir, sesh_name: []const u8) !bool {
         std.log.info("creating session={s}", .{sesh_name});
         const server_sock_fd: lib_posix.socket_t = try socket.createSocket(
+            io,
             self.socket_path,
             self.cfg.socketMode(),
         );

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -684,7 +684,10 @@ pub const Daemon = struct {
 
     fn run(self: *Daemon, io: std.Io, dir: std.Io.Dir, sesh_name: []const u8) !bool {
         std.log.info("creating session={s}", .{sesh_name});
-        const server_sock_fd: lib_posix.socket_t = try socket.createSocket(self.socket_path);
+        const server_sock_fd: lib_posix.socket_t = try socket.createSocket(
+            self.socket_path,
+            self.cfg.socketMode(),
+        );
         const log_fd = log.log_system.file.?.handle;
 
         var keep_fds_open = [_]i32{ server_sock_fd, dir.handle, log_fd };

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -686,7 +686,9 @@ pub const Daemon = struct {
         std.log.info("creating session={s}", .{sesh_name});
         const server_sock_fd: lib_posix.socket_t = try socket.createSocket(
             io,
+            dir,
             self.socket_path,
+            sesh_name,
             self.cfg.socketMode(),
         );
         const log_fd = log.log_system.file.?.handle;

--- a/src/main.zig
+++ b/src/main.zig
@@ -537,8 +537,9 @@ fn help(io: std.Io) !void {
         \\  TMPDIR               Socket directory (priority 3)
         \\  ZMX_SESSION          Session name (injected automatically)
         \\  ZMX_SESSION_PREFIX   Prefix added to all session names
-        \\  ZMX_DIR_MODE         Sets mode for socket and log directories (octal, defaults to 0750)
-        \\  ZMX_LOG_MODE         Sets mode for log files (octal, defaults to 0640)
+        \\  ZMX_DIR_MODE         Sets mode for socket and log directories (octal, defaults to 0700)
+        \\                       Socket mode is ZMX_DIR_MODE without the execute bits
+        \\  ZMX_LOG_MODE         Sets mode for log files (octal, defaults to 0600)
         \\  ZMX_NO_DETACH_KEY    Disables the ctrl+\ detach shortcut (set to any value)
         \\
     ;

--- a/src/socket.zig
+++ b/src/socket.zig
@@ -94,7 +94,7 @@ pub fn sessionExists(io: std.Io, dir: std.Io.Dir, name: []const u8) !bool {
     return true;
 }
 
-pub fn createSocket(io: std.Io, sesh: []const u8, socket_mode: u32) !lib_posix.socket_t {
+pub fn createSocket(io: std.Io, dir: std.Io.Dir, sesh: []const u8, sesh_name: []const u8, socket_mode: u32) !lib_posix.socket_t {
     // AF.UNIX: Unix domain socket for local IPC with client processes
     // SOCK.STREAM: Reliable, bidirectional communication
     // SOCK.NONBLOCK: Set socket to non-blocking
@@ -108,11 +108,11 @@ pub fn createSocket(io: std.Io, sesh: []const u8, socket_mode: u32) !lib_posix.s
     var unix_addr = try lib_posix.initUnix(sesh);
     try lib_posix.bind(fd, &unix_addr.any, unix_addr.getOsSockLen());
     try std.Io.Dir.setFilePermissions(
-        .cwd(),
+        dir,
         io,
-        sesh,
+        sesh_name,
         std.Io.File.Permissions.fromMode(@intCast(socket_mode)),
-        .{},
+        .{ .follow_symlinks = false },
     );
     try lib_posix.listen(fd, 128);
     return fd;

--- a/src/socket.zig
+++ b/src/socket.zig
@@ -1,5 +1,6 @@
 const std = @import("std");
 const lib_posix = @import("posix.zig");
+const cross = @import("cross.zig");
 
 pub fn getSeshPrefix() []const u8 {
     return lib_posix.getenv("ZMX_SESSION_PREFIX") orelse "";
@@ -94,7 +95,7 @@ pub fn sessionExists(io: std.Io, dir: std.Io.Dir, name: []const u8) !bool {
     return true;
 }
 
-pub fn createSocket(sesh: []const u8) !lib_posix.socket_t {
+pub fn createSocket(sesh: []const u8, socket_mode: u32) !lib_posix.socket_t {
     // AF.UNIX: Unix domain socket for local IPC with client processes
     // SOCK.STREAM: Reliable, bidirectional communication
     // SOCK.NONBLOCK: Set socket to non-blocking
@@ -106,6 +107,9 @@ pub fn createSocket(sesh: []const u8) !lib_posix.socket_t {
     errdefer lib_posix.close(fd);
 
     var unix_addr = try lib_posix.initUnix(sesh);
+    // bind() creates the socket as 0777 & ~umask, so adjust umask here
+    const old_umask = cross.c.umask(@intCast((~socket_mode) & 0o777));
+    defer _ = cross.c.umask(old_umask);
     try lib_posix.bind(fd, &unix_addr.any, unix_addr.getOsSockLen());
     try lib_posix.listen(fd, 128);
     return fd;

--- a/src/socket.zig
+++ b/src/socket.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 const lib_posix = @import("posix.zig");
-const cross = @import("cross.zig");
 
 pub fn getSeshPrefix() []const u8 {
     return lib_posix.getenv("ZMX_SESSION_PREFIX") orelse "";
@@ -95,7 +94,7 @@ pub fn sessionExists(io: std.Io, dir: std.Io.Dir, name: []const u8) !bool {
     return true;
 }
 
-pub fn createSocket(sesh: []const u8, socket_mode: u32) !lib_posix.socket_t {
+pub fn createSocket(io: std.Io, sesh: []const u8, socket_mode: u32) !lib_posix.socket_t {
     // AF.UNIX: Unix domain socket for local IPC with client processes
     // SOCK.STREAM: Reliable, bidirectional communication
     // SOCK.NONBLOCK: Set socket to non-blocking
@@ -107,10 +106,14 @@ pub fn createSocket(sesh: []const u8, socket_mode: u32) !lib_posix.socket_t {
     errdefer lib_posix.close(fd);
 
     var unix_addr = try lib_posix.initUnix(sesh);
-    // bind() creates the socket as 0777 & ~umask, so adjust umask here
-    const old_umask = cross.c.umask(@intCast((~socket_mode) & 0o777));
-    defer _ = cross.c.umask(old_umask);
     try lib_posix.bind(fd, &unix_addr.any, unix_addr.getOsSockLen());
+    try std.Io.Dir.setFilePermissions(
+        .cwd(),
+        io,
+        sesh,
+        std.Io.File.Permissions.fromMode(@intCast(socket_mode)),
+        .{},
+    );
     try lib_posix.listen(fd, 128);
     return fd;
 }

--- a/test/permissions.bats
+++ b/test/permissions.bats
@@ -1,0 +1,31 @@
+#!/usr/bin/env bats
+# Socket and directory permission tests for zmx.
+
+load test_helper
+
+mode_of() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+@test "permissions: session socket is private regardless of umask" {
+  umask 000
+  run "$ZMX" run perm-default -d cat
+  [ "$status" -eq 0 ]
+  wait_for_session perm-default
+
+  [ "$(mode_of "$ZMX_DIR/perm-default")" = "600" ]
+}
+
+@test "permissions: ZMX_DIR_MODE widens the socket for group sharing" {
+  umask 022
+  export ZMX_DIR_MODE=770
+  # A fresh directory: mkdir does not restat or chmod an existing one.
+  export ZMX_DIR="$BATS_TEST_TMPDIR/zmx-shared"
+
+  run "$ZMX" run perm-shared -d cat
+  [ "$status" -eq 0 ]
+  wait_for_session perm-shared
+
+  [ "$(mode_of "$ZMX_DIR/perm-shared")" = "660" ]
+  [ "$(mode_of "$ZMX_DIR")" = "770" ]
+}


### PR DESCRIPTION
This changes the permission handling of sockets and directories by avoiding the influence of umask, and removes the group permissions from the default. 

The added test: `test/permissions.bats` shows the umask-related behavior that gets adjusted by this PR.

The changes to the defaults influence functionality around group shared sockets (0750 -> 0700), making zmx default closer to tmux and screen. If you don't like that and want socket directories to get group permissions by default, you might want to reject this part, but to me it seems sensible that all forms of group sharing require opt-in via ZMX_DIR_MODE.