### PR TITLE
feat(run): export ZMX_TASK in task sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Use spec: https://common-changelog.org/
 - We now track cwd changes via OSC7
 - Replay window title on attach
 - `ZMX_NO_DETACH_KEY` env var to disable `ctrl+\` keybinding
+- `ZMX_TASK=1` inside sessions created by `zmx run`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,11 @@ When you attach to a `zmx` session, we don't provide any indication that you are
 
 We recommend checking for that env var inside your prompt and displaying some indication there.
 
+Sessions created by `zmx run` also set `ZMX_TASK=1`. Nobody is watching those, so
+if your shell config is expensive or chatty, gate the prompt (and any greeter)
+on `ZMX_TASK` being unset — otherwise every prompt it draws ends up in the
+scrollback that `zmx history` returns.
+
 ### fish
 
 Place this file in `~/.config/fish/config.fish`:

--- a/src/daemonize.zig
+++ b/src/daemonize.zig
@@ -10,6 +10,7 @@ const cross = @import("cross.zig");
 const Cmd = struct {
     file: [*:0]const u8,
     argv_ptr: [*:null]const ?[*:0]const u8,
+    is_task_mode: bool,
 };
 
 pub fn createCmdZ(def_shell: []const u8, is_task_mode: bool, command: ?[]const []const u8) !Cmd {
@@ -23,6 +24,7 @@ pub fn createCmdZ(def_shell: []const u8, is_task_mode: bool, command: ?[]const [
         return .{
             .file = argv[0].?,
             .argv_ptr = argv.ptr,
+            .is_task_mode = is_task_mode,
         };
     }
 
@@ -37,6 +39,7 @@ pub fn createCmdZ(def_shell: []const u8, is_task_mode: bool, command: ?[]const [
     return .{
         .file = shell,
         .argv_ptr = argv,
+        .is_task_mode = is_task_mode,
     };
 }
 
@@ -69,6 +72,14 @@ fn exec(sesh_name: []const u8, cmd: Cmd) !noreturn {
         }
     } else {
         _ = cross.c.putenv(@constCast("TERM=xterm-256color"));
+    }
+
+    // Task sessions run a shell that nobody is watching, so shell configs
+    // want to skip prompts, greeters and other interactive-only output.
+    // ZMX_SESSION alone cannot express that: it is also set for `attach`.
+    if (cmd.is_task_mode) {
+        const task_env = try std.fmt.allocPrintSentinel(gpa, "ZMX_TASK=1", .{}, 0);
+        _ = cross.c.putenv(task_env.ptr);
     }
 
     const err = lib_posix.execvpeZ(cmd.file, cmd.argv_ptr, std.c.environ);

--- a/src/main.zig
+++ b/src/main.zig
@@ -536,6 +536,7 @@ fn help(io: std.Io) !void {
         \\  XDG_RUNTIME_DIR      Socket directory (priority 2)
         \\  TMPDIR               Socket directory (priority 3)
         \\  ZMX_SESSION          Session name (injected automatically)
+        \\  ZMX_TASK             Set to 1 inside `run` sessions (injected automatically)
         \\  ZMX_SESSION_PREFIX   Prefix added to all session names
         \\  ZMX_DIR_MODE         Sets mode for socket and log directories (octal, defaults to 0750)
         \\  ZMX_LOG_MODE         Sets mode for log files (octal, defaults to 0640)

--- a/test/task_env.bats
+++ b/test/task_env.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+# ZMX_TASK marks `run` sessions so shell configs can tell a task session apart
+# from an interactive `attach` and skip prompts and other interactive-only
+# output. ZMX_SESSION cannot express that: it is set for both.
+#
+# Markers are built with printf so the expected string never appears in the
+# command line itself: `zmx run` types the command into the PTY, which echoes
+# it back, and a marker matching that echo would pass before the command ran.
+
+load test_helper
+
+@test "run: exports ZMX_TASK=1 in the task session" {
+  run timeout 10 "$ZMX" run task-env-set -d bash -c 'printf "task=%s\n" "${ZMX_TASK-unset}"'
+  [ "$status" -eq 0 ]
+
+  wait_for_output task-env-set "task=1"
+  run "$ZMX" history task-env-set
+  [[ "$output" == *"task=1"* ]]
+}
+
+@test "run: ZMX_SESSION is still exported alongside ZMX_TASK" {
+  run timeout 10 "$ZMX" run task-env-both -d bash -c 'printf "sesh=%s\n" "${ZMX_SESSION-unset}"'
+  [ "$status" -eq 0 ]
+
+  wait_for_output task-env-both "sesh=task-env-both"
+  run "$ZMX" history task-env-both
+  [[ "$output" == *"sesh=task-env-both"* ]]
+}


### PR DESCRIPTION
## Goal

Let shell configuration distinguish sessions created by `zmx run` from interactive sessions. `ZMX_SESSION` is set in both cases, so task shells currently have no reliable way to suppress prompts, greeters, direnv messages, and other interactive-only output that otherwise lands in task scrollback.

This exports `ZMX_TASK=1` in the exec child when `is_task_mode` is set and documents the environment contract. BATS coverage verifies that both `ZMX_TASK` and `ZMX_SESSION` reach the task process.

## Reviewer focus

Please focus on whether the variable is injected at the right point in the fork/exec path without affecting interactive attach sessions or the parent process.

## Deliberate scope

The variable applies when `zmx run` creates the shell. It cannot be retroactively added to a shell from an existing interactive session, and this change intentionally does not alter task-shell selection or list output.