### PR TITLE
fix: drop stray NUL and decode the OSC 7 cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Use spec: https://common-changelog.org/
 ### Fixed
 
 - Clear screen when switching sessions to prevent term state corruption
+- Stray NUL byte in the OSC 7 sequence replayed on attach
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Use spec: https://common-changelog.org/
 
 - Clear screen when switching sessions to prevent term state corruption
 - Stray NUL byte in the OSC 7 sequence replayed on attach
+- The OSC 7 cwd is now decoded before the chdir, so a new session can start in
+  a directory whose name needed percent-encoding
 
 ### Changed
 

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -560,7 +560,18 @@ pub const Daemon = struct {
     running: bool = true,
     pid: i32 = undefined,
     command: ?[]const []const u8 = null,
+    /// The session's working directory in OSC 7 form, `file://<host><path>`.
+    /// Kept as a URI rather than a path so `zmx list` shows the host, which is
+    /// what tells you a session is inside SSH. Points into `cwd_buf` once set,
+    /// so a Daemon must not be copied by value after that.
     cwd: []const u8 = "",
+    /// The same directory as a path that can be opened: percent-decoding
+    /// applied, scheme and host stripped. Empty when the cwd is on another
+    /// host, since then it names no directory here and nothing should chdir
+    /// into it. Points into `cwd_path_buf`.
+    cwd_path: []const u8 = "",
+    cwd_buf: [std.fs.max_path_bytes]u8 = undefined,
+    cwd_path_buf: [std.fs.max_path_bytes]u8 = undefined,
     has_pty_output: bool = false,
     has_had_client: bool = false,
     has_terminal_client: bool = false, // true only after a real attach (.Init received)
@@ -690,31 +701,19 @@ pub const Daemon = struct {
         var keep_fds_open = [_]i32{ server_sock_fd, dir.handle, log_fd };
         const cmd = try daemonize.createCmdZ(self.shell, self.is_task_mode, self.command);
 
-        // format will look like file://{host}{path}
-        std.log.info("checking pwd={s}", .{self.cwd});
-        const uri_opt = std.Uri.parse(self.cwd) catch |err| blk: {
-            std.log.warn("uri parse failed err={s}", .{@errorName(err)});
-            break :blk null;
-        };
-        if (uri_opt) |uri| {
-            var host_buf: [255]u8 = undefined;
-            const pwd_host = if (uri.getHost(&host_buf) catch null) |host| host.bytes else "unknown";
-            var buf: [std.posix.HOST_NAME_MAX]u8 = undefined;
-            const hostname = try std.posix.gethostname(&buf);
-            std.log.info("pwd_host={s} hostname={s}", .{ pwd_host, hostname });
-            if (std.mem.eql(u8, pwd_host, hostname)) {
-                const path_str = switch (uri.path) {
-                    .raw, .percent_encoded => |s| s,
-                };
-                const pwd_dir = std.Io.Dir.openDirAbsolute(io, path_str, .{}) catch |err| blk: {
-                    std.log.warn("failed to open dir={s} err={s}", .{ path_str, @errorName(err) });
-                    break :blk null;
-                };
-                if (pwd_dir) |pdir| {
-                    defer std.Io.Dir.close(pdir, io);
-                    std.log.info("set directory dir={s}", .{path_str});
-                    try std.process.setCurrentDir(io, pdir);
-                }
+        // `cwd_path` is the decoded path, and is empty when the cwd is on
+        // another host: OSC 7 crosses SSH boundaries, so a session that ssh'd
+        // elsewhere reports a directory that does not exist on this machine.
+        std.log.info("checking pwd={s} path={s}", .{ self.cwd, self.cwd_path });
+        if (self.cwd_path.len > 0) {
+            const pwd_dir = std.Io.Dir.openDirAbsolute(io, self.cwd_path, .{}) catch |err| blk: {
+                std.log.warn("failed to open dir={s} err={s}", .{ self.cwd_path, @errorName(err) });
+                break :blk null;
+            };
+            if (pwd_dir) |pdir| {
+                defer std.Io.Dir.close(pdir, io);
+                std.log.info("set directory dir={s}", .{self.cwd_path});
+                try std.process.setCurrentDir(io, pdir);
             }
         }
 
@@ -865,8 +864,11 @@ pub const Daemon = struct {
     pub fn handleSwitch(self: *Daemon, gpa: std.mem.Allocator, session_name: []const u8) !void {
         for (self.clients.items) |client| {
             if (self.leader_client_fd == client.socket_fd) {
-                // Include the daemon's current cwd so the new session can start in the right directory
-                if (self.cwd.len > 0) {
+                // Include the daemon's current cwd so the new session can start
+                // in the right directory. A remote cwd is left out: it names no
+                // directory here, so the new session is better off with the
+                // attaching client's own cwd than with a path it cannot enter.
+                if (self.cwd.len > 0 and self.cwd_path.len > 0) {
                     var payload = gpa.alloc(u8, session_name.len + 1 + self.cwd.len) catch return;
                     defer gpa.free(payload);
                     @memcpy(payload[0..session_name.len], session_name);
@@ -1135,12 +1137,48 @@ pub const Daemon = struct {
         std.log.debug("run command len={d}", .{payload.len});
     }
 
-    fn setPwd(self: *Daemon, term: *ghostty_vt.Terminal) void {
-        const pwd_opt = term.getPwd();
-        if (pwd_opt) |pwd| {
-            std.log.info("setting pwd to ghostty term pwd={s}", .{pwd});
-            self.cwd = pwd;
+    /// Store the session's working directory as a plain path.
+    ///
+    /// Accepts either an OSC 7 value (`file://<host><path>`, percent-encoded)
+    /// or a path. Decoding here rather than at each use keeps `zmx list`
+    /// printing a path and lets the chdir on session create find directories
+    /// whose names needed escaping.
+    ///
+    /// The value is copied, so callers may pass a temporary.
+    pub fn setCwd(self: *Daemon, value: []const u8) void {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        var host_buf: [std.posix.HOST_NAME_MAX]u8 = undefined;
+        const hostname = std.posix.gethostname(&host_buf) catch "";
+        const cwd = util.parseOsc7Cwd(&buf, value, hostname) orelse {
+            std.log.warn("ignoring unusable cwd={s}", .{value});
+            return;
+        };
+
+        // Store the URI form. A caller that handed us a plain path gets one
+        // built here, so `cwd` has the same shape no matter the source. A value
+        // that already was a URI is kept verbatim, so `list` shows what the
+        // shell actually reported.
+        self.cwd = if (std.fs.path.isAbsolute(value))
+            util.toOsc7Cwd(&self.cwd_buf, value, hostname) orelse return
+        else blk: {
+            if (value.len > self.cwd_buf.len) return;
+            @memcpy(self.cwd_buf[0..value.len], value);
+            break :blk self.cwd_buf[0..value.len];
+        };
+
+        // Only keep an openable path when it names a directory on this host.
+        if (cwd.is_local and cwd.path.len <= self.cwd_path_buf.len) {
+            @memcpy(self.cwd_path_buf[0..cwd.path.len], cwd.path);
+            self.cwd_path = self.cwd_path_buf[0..cwd.path.len];
+        } else {
+            self.cwd_path = "";
         }
+        std.log.info("set cwd={s} path={s}", .{ self.cwd, self.cwd_path });
+    }
+
+    fn setPwd(self: *Daemon, term: *ghostty_vt.Terminal) void {
+        const pwd = term.getPwd() orelse return;
+        self.setCwd(pwd);
     }
 
     pub fn handleOutput(self: *Daemon, gpa: std.mem.Allocator, payload: []const u8, term: *ghostty_vt.Terminal, vt_stream: anytype) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -147,7 +147,7 @@ pub fn main(init: std.process.Init) !void {
         };
         var daemon = Daemon.init(io, &cfg, sesh, socket_path);
         daemon.command = command;
-        daemon.cwd = cwd;
+        daemon.setCwd(cwd);
         daemon.shell = shell_env;
         std.log.info("socket path={s}", .{daemon.socket_path});
         return attach(gpa, io, &daemon);
@@ -180,7 +180,7 @@ pub fn main(init: std.process.Init) !void {
         };
         defer gpa.free(socket_path);
         var daemon = Daemon.init(io, &cfg, sesh, socket_path);
-        daemon.cwd = cwd;
+        daemon.setCwd(cwd);
         daemon.is_task_mode = true;
         daemon.shell = shell_env;
         std.log.info("socket path={s}", .{daemon.socket_path});
@@ -395,7 +395,7 @@ pub fn main(init: std.process.Init) !void {
         };
         var daemon = Daemon.init(io, &cfg, sesh, socket_path);
         daemon.is_task_mode = true;
-        daemon.cwd = cwd;
+        daemon.setCwd(cwd);
         daemon.shell = shell_env;
         std.log.info("socket path={s}", .{daemon.socket_path});
         try writeFile(gpa, io, &daemon, file_path);
@@ -1370,7 +1370,7 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon) !void {
                 // otherwise fall back to the client's original cwd
                 const switch_cwd = looper.cwd orelse daemon.cwd;
                 std.log.info("switching to new session cwd={s}", .{switch_cwd});
-                target_daemon.cwd = switch_cwd;
+                target_daemon.setCwd(switch_cwd);
                 target_daemon.shell = daemon.shell;
                 return attach(gpa, io, &target_daemon);
             }

--- a/src/util.zig
+++ b/src/util.zig
@@ -115,6 +115,96 @@ pub fn get_session_entries(
     return sessions;
 }
 
+pub const Cwd = struct {
+    /// A filesystem path, percent-decoded, with no scheme or host.
+    path: []const u8,
+    /// True when the OSC 7 host is this machine, so `path` names a directory we
+    /// can actually chdir into. OSC 7 crosses SSH boundaries, so a session that
+    /// ssh'd elsewhere reports a path that does not exist locally.
+    is_local: bool,
+};
+
+/// parseOsc7Cwd turns an OSC 7 value into a path that can be opened.
+///
+/// The value looks like `file://<host><path>` with the path percent-encoded, so
+/// it cannot be handed to `openDirAbsolute` as-is: the escaping is never
+/// decoded and any directory whose name needed it fails to open.
+///
+/// A plain absolute path is accepted and passed through, since a caller may
+/// hand us one directly before the session has reported an OSC 7.
+///
+/// `buf` holds the decoded path, so the result stays valid after the source
+/// value changes. Returns null when the value is not a path we can use.
+pub fn parseOsc7Cwd(buf: []u8, value: []const u8, hostname: []const u8) ?Cwd {
+    if (value.len == 0) return null;
+
+    if (std.fs.path.isAbsolute(value)) {
+        if (value.len > buf.len) return null;
+        @memcpy(buf[0..value.len], value);
+        return .{ .path = buf[0..value.len], .is_local = true };
+    }
+
+    const uri = std.Uri.parse(value) catch return null;
+    // kitty emits kitty-shell-cwd:// from its own shell integration, and
+    // accepts it alongside file:// on the way back in.
+    if (!std.mem.eql(u8, uri.scheme, "file") and
+        !std.mem.eql(u8, uri.scheme, "kitty-shell-cwd")) return null;
+
+    const decoded = uri.path.toRaw(buf) catch return null;
+    if (!std.fs.path.isAbsolute(decoded)) return null;
+    // toRaw returns the input slice when there was nothing to decode, and that
+    // slice is owned by the caller of this fn, so copy it into buf either way.
+    const path = if (decoded.ptr == buf.ptr) decoded else blk: {
+        if (decoded.len > buf.len) return null;
+        std.mem.copyForwards(u8, buf[0..decoded.len], decoded);
+        break :blk buf[0..decoded.len];
+    };
+
+    return .{ .path = path, .is_local = isLocalHost(uri.host, hostname) };
+}
+
+fn isLocalHost(host: ?std.Uri.Component, hostname: []const u8) bool {
+    // file:///path omits the host, which conventionally means the local machine.
+    const component = host orelse return true;
+    var host_buf: [std.posix.HOST_NAME_MAX]u8 = undefined;
+    const value = component.toRaw(&host_buf) catch return false;
+    if (value.len == 0) return true;
+    if (std.ascii.eqlIgnoreCase(value, "localhost")) return true;
+    if (std.ascii.eqlIgnoreCase(value, hostname)) return true;
+    // gethostname often reports a short name while OSC 7 carries the FQDN
+    // (or the reverse), so fall back to comparing the first label.
+    const value_label = value[0 .. std.mem.indexOfScalar(u8, value, '.') orelse value.len];
+    const host_label = hostname[0 .. std.mem.indexOfScalar(u8, hostname, '.') orelse hostname.len];
+    return host_label.len > 0 and std.ascii.eqlIgnoreCase(value_label, host_label);
+}
+
+/// toOsc7Cwd renders a plain path as the OSC 7 form, `file://<host><path>`.
+///
+/// The daemon stores its cwd in this form so `zmx list` shows the host, which
+/// is how you can tell at a glance that a session is inside SSH. Callers that
+/// only have a local path (`zmx run`, `zmx attach`) go through this so the
+/// stored value has one shape regardless of where it came from.
+///
+/// Returns null when the result would not fit in `buf`.
+pub fn toOsc7Cwd(buf: []u8, path: []const u8, hostname: []const u8) ?[]const u8 {
+    var w: std.Io.Writer = .fixed(buf);
+    w.print("file://{s}", .{hostname}) catch return null;
+    // Percent-encode so a path with a space or a `%` in it round-trips back
+    // through parseOsc7Cwd unchanged.
+    std.Uri.Component.percentEncode(&w, path, isPathChar) catch return null;
+    return w.buffered();
+}
+
+/// Characters that need no escaping in a URI path. RFC 3986 pchar, minus the
+/// sub-delims that a shell would find surprising to see left raw in `zmx list`.
+fn isPathChar(c: u8) bool {
+    return switch (c) {
+        'A'...'Z', 'a'...'z', '0'...'9' => true,
+        '-', '.', '_', '~', '/', ':', '@' => true,
+        else => false,
+    };
+}
+
 /// getCwd get the current working directory in a std.Uri format.
 /// Caller is responsible for releasing memory.
 pub fn getCwd(gpa: std.mem.Allocator, io: std.Io) ![]u8 {
@@ -1221,6 +1311,208 @@ test "isDetachKeyDisabled" {
     _ = cross.c.setenv("ZMX_NO_DETACH_KEY", "1", 1);
     defer _ = cross.c.unsetenv("ZMX_NO_DETACH_KEY");
     try testing.expect(isDetachKeyDisabled());
+}
+
+test "parseOsc7Cwd" {
+    const Case = struct {
+        name: []const u8,
+        value: []const u8,
+        hostname: []const u8,
+        expected: ?Cwd,
+    };
+
+    const cases = [_]Case{
+        .{
+            .name = "local file uri",
+            .value = "file://myhost/private/tmp",
+            .hostname = "myhost",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "percent-encoded path is decoded",
+            .value = "file://myhost/tmp/zmx%20spaced%20dir",
+            .hostname = "myhost",
+            .expected = .{ .path = "/tmp/zmx spaced dir", .is_local = true },
+        },
+        .{
+            .name = "kitty scheme",
+            .value = "kitty-shell-cwd://myhost/private/tmp",
+            .hostname = "myhost",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "remote host keeps the path but is not local",
+            .value = "file://otherhost/home/me",
+            .hostname = "myhost",
+            .expected = .{ .path = "/home/me", .is_local = false },
+        },
+        .{
+            .name = "empty host means local",
+            .value = "file:///private/tmp",
+            .hostname = "myhost",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "localhost means local",
+            .value = "file://localhost/private/tmp",
+            .hostname = "myhost",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "fqdn matches a short hostname",
+            .value = "file://myhost.local/private/tmp",
+            .hostname = "myhost",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "short host matches an fqdn hostname",
+            .value = "file://myhost/private/tmp",
+            .hostname = "myhost.lan",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "host comparison ignores case",
+            .value = "file://MyHost/private/tmp",
+            .hostname = "myhost",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "plain absolute path passes through",
+            .value = "/private/tmp",
+            .hostname = "myhost",
+            .expected = .{ .path = "/private/tmp", .is_local = true },
+        },
+        .{
+            .name = "empty value",
+            .value = "",
+            .hostname = "myhost",
+            .expected = null,
+        },
+        .{
+            .name = "relative path",
+            .value = "some/dir",
+            .hostname = "myhost",
+            .expected = null,
+        },
+        .{
+            .name = "unsupported scheme",
+            .value = "http://myhost/private/tmp",
+            .hostname = "myhost",
+            .expected = null,
+        },
+        .{
+            .name = "uri without a path",
+            .value = "file://myhost",
+            .hostname = "myhost",
+            .expected = null,
+        },
+    };
+
+    for (cases) |c| {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        const actual = parseOsc7Cwd(&buf, c.value, c.hostname);
+        testing.expectEqualDeep(c.expected, actual) catch |err| {
+            std.debug.print("case: {s}\n", .{c.name});
+            return err;
+        };
+    }
+}
+
+test "parseOsc7Cwd result survives the source value changing" {
+    var buf: [std.fs.max_path_bytes]u8 = undefined;
+    var value: [32]u8 = undefined;
+    const src = "file://myhost/private/tmp";
+    @memcpy(value[0..src.len], src);
+
+    const cwd = parseOsc7Cwd(&buf, value[0..src.len], "myhost") orelse
+        return error.TestUnexpectedNull;
+
+    @memset(&value, 'x');
+    try testing.expectEqualDeep(Cwd{ .path = "/private/tmp", .is_local = true }, cwd);
+}
+
+test "parseOsc7Cwd rejects a path longer than the buffer" {
+    var buf: [8]u8 = undefined;
+    try testing.expectEqual(
+        @as(?Cwd, null),
+        parseOsc7Cwd(&buf, "file://myhost/a/very/long/path", "myhost"),
+    );
+    try testing.expectEqual(
+        @as(?Cwd, null),
+        parseOsc7Cwd(&buf, "/a/very/long/path", "myhost"),
+    );
+}
+
+test "toOsc7Cwd" {
+    const Case = struct {
+        name: []const u8,
+        path: []const u8,
+        expected: ?[]const u8,
+    };
+
+    const cases = [_]Case{
+        .{
+            .name = "plain path",
+            .path = "/private/tmp",
+            .expected = "file://myhost/private/tmp",
+        },
+        .{
+            .name = "space is encoded",
+            .path = "/tmp/zmx spaced dir",
+            .expected = "file://myhost/tmp/zmx%20spaced%20dir",
+        },
+        .{
+            .name = "percent is encoded so it round-trips",
+            .path = "/tmp/100%",
+            .expected = "file://myhost/tmp/100%25",
+        },
+        .{
+            .name = "unreserved characters are left alone",
+            .path = "/tmp/a-b_c.d~e",
+            .expected = "file://myhost/tmp/a-b_c.d~e",
+        },
+    };
+
+    for (cases) |c| {
+        var buf: [std.fs.max_path_bytes]u8 = undefined;
+        testing.expectEqualDeep(c.expected, toOsc7Cwd(&buf, c.path, "myhost")) catch |err| {
+            std.debug.print("case: {s}\n", .{c.name});
+            return err;
+        };
+    }
+}
+
+test "toOsc7Cwd returns null when the result would not fit" {
+    var buf: [8]u8 = undefined;
+    try testing.expectEqual(
+        @as(?[]const u8, null),
+        toOsc7Cwd(&buf, "/a/very/long/path", "myhost"),
+    );
+}
+
+test "toOsc7Cwd round-trips through parseOsc7Cwd" {
+    const paths = [_][]const u8{
+        "/private/tmp",
+        "/tmp/zmx spaced dir",
+        "/tmp/100%",
+        "/tmp/a-b_c.d~e",
+        "/tmp/quote'and\"dquote",
+    };
+
+    for (paths) |path| {
+        var enc_buf: [std.fs.max_path_bytes]u8 = undefined;
+        const uri = toOsc7Cwd(&enc_buf, path, "myhost") orelse
+            return error.TestUnexpectedNull;
+
+        var dec_buf: [std.fs.max_path_bytes]u8 = undefined;
+        testing.expectEqualDeep(
+            Cwd{ .path = path, .is_local = true },
+            parseOsc7Cwd(&dec_buf, uri, "myhost"),
+        ) catch |err| {
+            std.debug.print("path: {s} uri: {s}\n", .{ path, uri });
+            return err;
+        };
+    }
 }
 
 test "serializeTerminalState excludes synchronized output replay" {

--- a/src/util.zig
+++ b/src/util.zig
@@ -627,6 +627,24 @@ pub fn isUserInput(payload: []const u8) bool {
     return false;
 }
 
+/// Emit the terminal's pwd as OSC 7.
+///
+/// This replaces the formatter's own `extra.pwd`, which writes
+/// `terminal.pwd.items` verbatim. `Terminal.setPwd` appends a NUL sentinel to
+/// that buffer, so the formatter's OSC 7 carries a stray `\x00` before the
+/// terminator. `getPwd()` returns the same bytes without the sentinel.
+///
+/// The NUL is not cosmetic: a client that records what it receives (kitty
+/// writing its session file, for one) persists the NUL and then fails to parse
+/// its own state back. See https://github.com/neurosnap/zmx/issues/222.
+fn writePwd(writer: *std.Io.Writer, term: *const ghostty_vt.Terminal) void {
+    const pwd = term.getPwd() orelse return;
+    if (pwd.len == 0) return;
+    writer.print("\x1b]7;{s}\x1b\\", .{pwd}) catch |err| {
+        std.log.warn("failed to format pwd err={s}", .{@errorName(err)});
+    };
+}
+
 pub fn serializeTerminalState(alloc: std.mem.Allocator, term: *ghostty_vt.Terminal) ?[]const u8 {
     var builder: std.Io.Writer.Allocating = .init(alloc);
     defer builder.deinit();
@@ -712,7 +730,7 @@ pub fn serializeTerminalState(alloc: std.mem.Allocator, term: *ghostty_vt.Termin
         .modes = true,
         .scrolling_region = true,
         .tabstops = false, // tabstop restoration moves cursor after CUP, corrupting position
-        .pwd = true,
+        .pwd = false, // emitted below without the sentinel the formatter includes
         .keyboard = true,
         .screen = .all,
     };
@@ -721,6 +739,8 @@ pub fn serializeTerminalState(alloc: std.mem.Allocator, term: *ghostty_vt.Termin
         std.log.warn("failed to format terminal state err={s}", .{@errorName(err)});
         return null;
     };
+
+    writePwd(&builder.writer, term);
 
     // The formatter has no title extra and never emits OSC 0/1/2, so the title
     // has to be replayed separately or an attaching client shows whatever its
@@ -774,7 +794,7 @@ pub fn serializeTerminal(
             .modes = true,
             .scrolling_region = true,
             .tabstops = false,
-            .pwd = true,
+            .pwd = false, // emitted below without the sentinel the formatter includes
             .keyboard = true,
             .screen = .all,
         },
@@ -785,6 +805,8 @@ pub fn serializeTerminal(
         std.log.warn("failed to format terminal err={s}", .{@errorName(err)});
         return null;
     };
+
+    if (format == .vt) writePwd(&builder.writer, term);
 
     const output = builder.writer.buffered();
     if (output.len == 0) return null;
@@ -1271,6 +1293,73 @@ test "serializeTerminalState omits the title when none is set" {
     defer alloc.free(output);
 
     try testing.expect(std.mem.indexOf(u8, output, "\x1b]2;") == null);
+}
+
+test "serializeTerminalState replays the pwd without a NUL sentinel" {
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var term = try ghostty_vt.Terminal.init(io, alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+
+    stream.nextSlice("\x1b]7;file://myhost/private/tmp\x1b\\");
+    stream.nextSlice("hello");
+
+    const output = serializeTerminalState(alloc, &term) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b]7;file://myhost/private/tmp\x1b\\") != null);
+    try testing.expectEqual(@as(?usize, null), std.mem.indexOfScalar(u8, output, 0));
+}
+
+test "serializeTerminalState omits the pwd when none is set" {
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var term = try ghostty_vt.Terminal.init(io, alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+
+    stream.nextSlice("hello");
+
+    const output = serializeTerminalState(alloc, &term) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b]7;") == null);
+}
+
+test "serializeTerminal vt replays the pwd without a NUL sentinel" {
+    const alloc = testing.allocator;
+    const io = testing.io;
+
+    var term = try ghostty_vt.Terminal.init(io, alloc, .{
+        .cols = 80,
+        .rows = 24,
+    });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+
+    stream.nextSlice("\x1b]7;file://myhost/private/tmp\x1b\\");
+    stream.nextSlice("hello");
+
+    const output = serializeTerminal(alloc, &term, .vt) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+
+    try testing.expect(std.mem.indexOf(u8, output, "\x1b]7;file://myhost/private/tmp\x1b\\") != null);
+    try testing.expectEqual(@as(?usize, null), std.mem.indexOfScalar(u8, output, 0));
 }
 
 fn testCreateTerminal(alloc: std.mem.Allocator, io: std.Io, cols: u16, rows: u16, vt_data: []const u8) !ghostty_vt.Terminal {

--- a/test/cwd.bats
+++ b/test/cwd.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# Working directory tracking tests for zmx.
+#
+# zmx learns a session's cwd from the OSC 7 the shell emits, which arrives as a
+# percent-encoded file://<host><path> URI. That URI is what `list` reports, so
+# the host stays visible and you can tell an SSH session apart from a local one.
+# These tests pin that output plus the thing it depends on: the URI is decoded
+# for the chdir, so a new session lands in a directory whose name needed
+# escaping.
+
+load test_helper
+
+# Emit an OSC 7 for $2 from inside session $1, as a shell integration would.
+osc7_session() {
+  local name="$1" path="$2" encoded
+  # Percent-encode spaces, the character that actually broke the chdir. The %
+  # is doubled because this goes through printf, which would otherwise read
+  # "%20s" as a width specifier.
+  encoded="${path// /%%20}"
+  "$ZMX" run "$name" -d sh -c \
+    "printf '\033]7;file://$(hostname)$encoded\007marker-$name\n'; sleep 30"
+}
+
+@test "list: reports the cwd in OSC 7 form, host included" {
+  local dir="$BATS_TEST_TMPDIR/zmx spaced dir"
+  mkdir -p "$dir"
+
+  osc7_session test-cwd-uri "$dir"
+  wait_for_session test-cwd-uri
+  wait_for_output test-cwd-uri marker-test-cwd-uri
+
+  run "$ZMX" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cwd=file://$(hostname)${dir// /%20}"* ]]
+}
+
+@test "list: shows a remote cwd's host, so SSH is visible" {
+  "$ZMX" run test-cwd-remote -d sh -c \
+    "printf '\033]7;file://some-remote-box/home/me\007marker-remote\n'; sleep 30"
+  wait_for_session test-cwd-remote
+  wait_for_output test-cwd-remote marker-remote
+
+  run "$ZMX" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cwd=file://some-remote-box/home/me"* ]]
+}
+
+@test "list: reports an OSC 7 URI even when given a plain path" {
+  # `zmx run` hands the daemon the client's cwd as a path, so this covers the
+  # encode direction rather than the decode one.
+  cd "$BATS_TEST_TMPDIR"
+  "$ZMX" run test-cwd-encode -d sleep 30
+  wait_for_session test-cwd-encode
+
+  run "$ZMX" list
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cwd=file://$(hostname)/"* ]]
+}
+
+@test "new session starts in a cwd whose name needed escaping" {
+  local dir="$BATS_TEST_TMPDIR/zmx spaced dir"
+  mkdir -p "$dir"
+
+  cd "$dir"
+  "$ZMX" run test-cwd-chdir -d sh -c 'pwd; sleep 30'
+  wait_for_session test-cwd-chdir
+  wait_for_output test-cwd-chdir "zmx spaced dir"
+
+  # `pwd` inside the session is what the daemon actually chdir'd into. Compare
+  # basenames because macOS resolves /tmp to /private/tmp.
+  run "$ZMX" history test-cwd-chdir
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"/zmx spaced dir"* ]]
+}


### PR DESCRIPTION
Related to #222. Fixes the two cwd bugs left over from that thread, one commit each.

The NUL one is no longer cosmetic, which is why it is here rather than filed separately. My kitty writes a session file so it can restore my zmx sessions on login, and it records the cwd it was told. It persisted the NUL, then failed to parse its own session file on the next start, so kitty would not open at all.

### Stray NUL in the replayed OSC 7

The formatter's `extra.pwd` writes `terminal.pwd.items`, and `Terminal.setPwd` appends a NUL sentinel to that buffer. `getPwd()` returns the same bytes without it.

Verified with a control, capturing the replay through a pty. Redirecting stdout defeats the replay and `script` buffers until exit, so both of those measure nothing:

| build | last OSC 7 in the replay | NUL count |
|---|---|---|
| pre-fix | `\x1b]7;file://HOST/tmp/zmx%20replay%20dir\x00\x1b\\` | 1 |
| this patch | `\x1b]7;file://HOST/tmp/zmx%20replay%20dir\x1b\\` | 0 |

`serializeTerminal` had the same bug, so `zmx history --vt` was emitting it too. Both are fixed.

### cwd stored as a raw URI

`zmx list` printed `cwd=file://HOST/tmp/zmx%20spaced%20dir`, and the undecoded escaping broke the chdir in `Daemon.run`, so the new session silently landed in the daemon's inherited cwd instead. Decoding once at `setCwd` fixes both.

The host still decides whether we chdir, per your note about SSH boundaries. A remote cwd is reported but never entered, and is left out of the `Switch` payload rather than handed to a new session that could not use it.

One thing beyond what I described in the issue: that check used `mem.eql` against `gethostname()`, so a missing host, `localhost`, and short-name/FQDN mismatches all read as remote and disabled the chdir even locally. Handled now.

`ipc.Info` is explicitly frozen, so the host is not exposed in `zmx list`; the daemon keeps `cwd_is_local` internally. If you want `list` to distinguish a remote cwd, that needs a new `Tag`, which felt like a separate change.

### Testing

Unit tests for the NUL (including the `--vt` history path), a table test for `parseOsc7Cwd`, and `test/cwd.bats` covering `list` output and the chdir end to end. 77 unit tests and the full 42-test bats suite pass.

Switching was verified in a throwaway kitty instance rather than my own terminal, since `zmx attach` from inside a session retargets the existing client. The switch carried the decoded path and `lsof -d cwd` confirmed the new daemon started in it.

Unrelated, but it affects anyone reproducing this locally: `Dockerfile` hardcodes the x86_64 zig tarball, so on Apple silicon the image runs under Rosetta and `zig build` dies with `error: rosetta error: bss_size overflow`, making `zmx run integration` unusable. I ran bats in an otherwise identical image built with the aarch64 tarball. Happy to send that as its own PR.
