### PR TITLE
build: fetch the zig tarball for the host arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,21 @@ FROM debian:12
 RUN apt-get update && apt-get install -y curl git bats coreutils && rm -rf /var/lib/apt/lists/*
 
 ARG ZIG_VERSION=0.16.0
-RUN curl -L -o /tmp/zig.tar.xz https://ziglang.org/download/${ZIG_VERSION}/zig-x86_64-linux-${ZIG_VERSION}.tar.xz && \
+# `uname -m` already reports the names zig uses in its tarballs (x86_64,
+# aarch64), so it needs no mapping. Hardcoding x86_64 here meant the image ran
+# under emulation on an arm64 host, where `zig build` dies with
+# "rosetta error: bss_size overflow".
+RUN ARCH="$(uname -m)" && \
+	case "$ARCH" in \
+	  x86_64|aarch64) ;; \
+	  *) echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+	esac && \
+	curl -L -o /tmp/zig.tar.xz https://ziglang.org/download/${ZIG_VERSION}/zig-${ARCH}-linux-${ZIG_VERSION}.tar.xz && \
 	cd /tmp && \
-	tar -xvf zig.tar.xz && \
-  mv zig-x86_64-linux-${ZIG_VERSION} /usr/local/zig && \
-  ln -s /usr/local/zig/zig /usr/local/bin/zig
+	tar -xf zig.tar.xz && \
+	mv zig-${ARCH}-linux-${ZIG_VERSION} /usr/local/zig && \
+	ln -s /usr/local/zig/zig /usr/local/bin/zig && \
+	rm -f /tmp/zig.tar.xz
 
 ENV PATH=/usr/local/zig:$PATH
 


### PR DESCRIPTION
`Dockerfile` hardcodes the x86_64 zig tarball, so on an arm64 host the image runs under emulation and `zig build` dies before compiling anything:

```
error: rosetta error: bss_size overflow
```

That makes `zmx run build`, `test`, `fmt`, and `integration` from `pico.sh` unusable on Apple silicon. I hit it while running the integration suite for #232 and worked around it with a locally patched image, which is what prompted this.

`uname -m` already reports the names zig uses in its tarballs (`x86_64`, `aarch64`), so substituting it needs no mapping table. Unknown arches now fail with their own name instead of a 404 from ziglang.org.

Two incidental cleanups in the same `RUN`: dropped `-v` from `tar`, which printed a line per extracted file, and removed the tarball after extracting it.

### Testing

All four pico.sh targets, run natively on arm64:

| target | result |
|---|---|
| `zig build` | binary produced |
| `zig build test` | 71/71 passed |
| `zig fmt --check` | clean on tracked source |
| `bats test/*.bats` | 39 tests, 0 failures |

Also checked the two ways a change like this can go wrong:

- `--platform linux/amd64` still fetches the x86_64 tarball and lands `zig` reporting `x86_64`, so nothing changes for existing users or CI.
- `--platform linux/arm/v7` fails fast with `unsupported arch: armv7l` and a nonzero exit, rather than a confusing download failure.

One thing I left alone: `zig fmt --check .` also reports hits in vendored `zig-pkg`, so that target is noisy independent of arch. `.dockerignore` cannot fix it, since `pico.sh` bind-mounts the tree and bypasses it. Happy to scope that target to `src test build.zig` in a separate PR if you want it.
