### PR TITLE
fix: write/reset osc 10/11/12 on attach/detach

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -1312,12 +1312,14 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon) !void {
     var orig_termios: cross.c.termios = undefined;
     const stdin_is_tty = cross.c.tcgetattr(lib_posix.STDIN_FILENO, &orig_termios) == 0;
 
+    // RIS, OSC 10/11/12
+    const restore_seq = "\x1bc\x1b]110\x1b\\\x1b]111\x1b\\\x1b]112\x1b\\";
+
     defer {
         if (stdin_is_tty) {
             _ = cross.c.tcsetattr(lib_posix.STDIN_FILENO, cross.c.TCSAFLUSH, &orig_termios);
         }
         // Reset terminal modes on detach
-        const restore_seq = "\x1bc";
         _ = lib_posix.write(lib_posix.STDOUT_FILENO, restore_seq) catch {};
     }
 
@@ -1350,7 +1352,6 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon) !void {
         .switch_session => {
             if (looper.session_name) |session_name| {
                 // Reset terminal modes when switching sessions
-                const restore_seq = "\x1bc";
                 _ = lib_posix.write(lib_posix.STDOUT_FILENO, restore_seq) catch {};
 
                 const target_path = socket.getSocketPath(

--- a/src/util.zig
+++ b/src/util.zig
@@ -746,6 +746,26 @@ fn writePwd(writer: *std.Io.Writer, term: *const ghostty_vt.Terminal) void {
     };
 }
 
+fn writeDynamicColor(
+    writer: *std.Io.Writer,
+    kind: ghostty_vt.color.Dynamic,
+    dynamic: ghostty_vt.color.DynamicRGB,
+) void {
+    const c = dynamic.override orelse return;
+    writer.print("\x1b]{d};rgb:{x:0>2}/{x:0>2}/{x:0>2}\x1b\\", .{
+        @intFromEnum(kind), c.r, c.g, c.b,
+    }) catch |err| {
+        std.log.warn("failed to format dynamic color err={s}", .{@errorName(err)});
+    };
+}
+
+fn writeColorOverrides(writer: *std.Io.Writer, term: *const ghostty_vt.Terminal) void {
+    const colors = &term.colors;
+    writeDynamicColor(writer, .foreground, colors.foreground);
+    writeDynamicColor(writer, .background, colors.background);
+    writeDynamicColor(writer, .cursor, colors.cursor);
+}
+
 pub fn serializeTerminalState(alloc: std.mem.Allocator, term: *ghostty_vt.Terminal) ?[]const u8 {
     var builder: std.Io.Writer.Allocating = .init(alloc);
     defer builder.deinit();
@@ -759,6 +779,9 @@ pub fn serializeTerminalState(alloc: std.mem.Allocator, term: *ghostty_vt.Termin
     if (had_synchronized_output) {
         term.modes.set(.synchronized_output, false);
     }
+
+    // If state contains color override, restore it.
+    writeColorOverrides(&builder.writer, term);
 
     const pages = &term.screens.active.pages;
     const screen_top = pages.getTopLeft(.screen);


### PR DESCRIPTION
Fixes restoration of OSC 10/11/12 colors on reattach.

Also changed the reset sequence to include the OSC 10/11/12 resets. Kitty does this for `\x1bc`, but terminals like Ghostty don't (which I'm using in the example).

## Before
https://github.com/user-attachments/assets/90094f63-cd48-43b2-bb64-af369ec6d5e0

## After
https://github.com/user-attachments/assets/8ec86ad7-2362-437d-9d11-241e3e2218ee
