### PR TITLE
fix(docs): handle ZMX_SESSION_PREFIX in session picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,11 +253,16 @@ Requires [fzf](https://github.com/junegunn/fzf).
 ```bash
 zmx-select() {
   local display
+  local prefix="${ZMX_SESSION_PREFIX:-}"
   display=$(zmx list 2>/dev/null | while IFS=$'\t' read -r name pid clients created dir; do
     name=${name#*name=}
     pid=${pid#*pid=}
     clients=${clients#*clients=}
     dir=${dir#*start_dir=}
+    if [[ -n "$prefix" ]]; then
+      [[ "$name" == "$prefix"* ]] || continue
+      name=${name#"$prefix"}
+    fi
     printf "%-20s  pid:%-8s  clients:%-2s  %s\n" "$name" "$pid" "$clients" "$dir"
   done)
 


### PR DESCRIPTION
## Summary

- scope the README picker to sessions in the active `ZMX_SESSION_PREFIX` namespace
- strip one prefix before passing session names to `fzf`, so preview and attach add it exactly once
- preserve Ctrl-N creation and no-prefix behavior

Fixes #216

## Testing

- Ran: mock `zmx`/`fzf` picker regression cases in Bash and Zsh
- Ran: `shellcheck -e SC2034 -s bash` on the picker snippet
- Ran: `zsh -n` on the picker snippet
- Ran: `git diff --check`