### PR TITLE
feat(snapshot): daemon sends libghostty snapshots instead of raw bytestream

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -20,7 +20,10 @@ pub fn build(b: *std.Build) void {
 
     const options = b.addOptions();
     options.addOption([]const u8, "version", version);
-    const ghostty_ver = build_zig_zon.dependencies.ghostty.hash;
+    const ghostty_ver = if (@hasField(@TypeOf(build_zig_zon.dependencies.ghostty), "hash"))
+        build_zig_zon.dependencies.ghostty.hash
+    else
+        "local-dev";
     options.addOption([]const u8, "ghostty_version", ghostty_ver);
 
     const exe_mod = b.createModule(.{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
         .ghostty = .{
-            .url = "git+https://github.com/ghostty-org/ghostty/#aa21caeaa3a2feb6ef1251d20bd81b52f1da0940",
-            .hash = "ghostty-1.3.2-dev-5UdBCw7jLQVbzMzfCu-BNb7P4o6P3L9WjORwuelawrt6",
+            .url = "git+https://github.com/ghostty-org/ghostty#8af6897c0afc63037a8a3efee4162a380e3a4572",
+            .hash = "ghostty-1.3.2-dev-5UdBC4FtYAV-PdFOt-gceWieTHLri0H4ztHtd6Tr4dGj",
         },
     },
     .paths = .{

--- a/src/cross.zig
+++ b/src/cross.zig
@@ -7,18 +7,21 @@ pub const c = switch (builtin.os.tag) {
         @cInclude("termios.h");
         @cInclude("stdlib.h");
         @cInclude("unistd.h");
+        @cInclude("time.h");
     }),
     .freebsd => @cImport({
         @cInclude("termios.h"); // ioctl and constants
         @cInclude("libutil.h"); // openpty()
         @cInclude("stdlib.h");
         @cInclude("unistd.h");
+        @cInclude("time.h");
     }),
     else => @cImport({
         @cInclude("sys/ioctl.h"); // ioctl and constants
         @cInclude("pty.h");
         @cInclude("stdlib.h");
         @cInclude("unistd.h");
+        @cInclude("time.h");
     }),
 };
 

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -26,6 +26,7 @@ pub const Tag = enum(u8) {
     EnvGet = 19,
     EnvSet = 20,
     EnvData = 21,
+    Snapshot = 22,
     // Non-exhaustive: this enum comes off the wire via bytesToValue and
     // @enumFromInt, so out-of-range values are representable
     // rather than UB. Switches must handle `_` (unknown tag).

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -12,10 +12,17 @@ const signal = @import("signal.zig");
 const assert = std.debug.assert;
 const daemonize = @import("daemonize.zig");
 const builtin = @import("builtin");
+const snapshot = @import("snapshot.zig");
 
 /// clientLoop sends ipc commands to its corresponding daemon.  It uses poll() as its non-blocking
 /// mechanism. It will send stdin to the daemon and receive stdout from the daemon.
-pub fn clientLoop(client_sock_fd: i32, env_str: []const u8) !ClientResult {
+pub fn clientLoop(
+    io: std.Io,
+    client_sock_fd: i32,
+    snapshot_mode: bool,
+    init_snapshot: []const u8,
+    env_str: []const u8,
+) !ClientResult {
     std.log.info("client loop fd={d}", .{client_sock_fd});
     const gpa: std.mem.Allocator = blk: {
         if (builtin.mode == .Debug) {
@@ -45,9 +52,8 @@ pub fn clientLoop(client_sock_fd: i32, env_str: []const u8) !ClientResult {
         try ipc.appendMessage(gpa, &sock_write_buf, .EnvSet, env_str);
     }
 
-    // Send init message with terminal size (buffered)
-    const size = ipc.getTerminalSize(lib_posix.STDOUT_FILENO);
-    try ipc.appendMessage(gpa, &sock_write_buf, .Init, std.mem.asBytes(&size));
+    // Send init message with terminal snapshot (buffered)
+    try ipc.appendMessage(gpa, &sock_write_buf, .Init, init_snapshot);
 
     var poll_fds = try std.ArrayList(lib_posix.pollfd).initCapacity(gpa, 4);
     defer poll_fds.deinit(gpa);
@@ -118,12 +124,14 @@ pub fn clientLoop(client_sock_fd: i32, env_str: []const u8) !ClientResult {
 
             if (n_opt) |n| {
                 if (n > 0) {
-                    // Check for detach sequences (ctrl+\ as first byte or Kitty escape sequence)
-                    if (!detach_key_disabled and util.isCtrlBackslash(buf[0..n])) {
+                    const input_slice = buf[0..n];
+                    if (std.mem.indexOf(u8, input_slice, "\x1b_Gsnap=req\x1b\\")) |_| {
+                        // Drop snapshot request marker from Monstar so it isn't forwarded as shell keystrokes
+                    } else if (!detach_key_disabled and util.isCtrlBackslash(input_slice)) {
                         std.log.info("detach key detected", .{});
                         try ipc.appendMessage(gpa, &sock_write_buf, .Detach, "");
                     } else {
-                        try ipc.appendMessage(gpa, &sock_write_buf, .Input, buf[0..n]);
+                        try ipc.appendMessage(gpa, &sock_write_buf, .Input, input_slice);
                     }
                 } else {
                     std.log.info("eof stdin", .{});
@@ -154,6 +162,30 @@ pub fn clientLoop(client_sock_fd: i32, env_str: []const u8) !ClientResult {
                     .Output => {
                         if (msg.payload.len > 0) {
                             try stdout_buf.appendSlice(gpa, msg.payload);
+                        }
+                    },
+                    .Snapshot => {
+                        if (msg.payload.len > 0) {
+                            if (snapshot_mode) {
+                                try stdout_buf.appendSlice(gpa, msg.payload);
+                            } else {
+                                var reader: std.Io.Reader = .fixed(msg.payload);
+                                if (snapshot.startImport(gpa, io, &reader, 1024 * 1024)) |import_res| {
+                                    var mut_res = import_res;
+                                    defer mut_res.deinit(gpa);
+                                    var restored_term = mut_res.terminal;
+                                    defer restored_term.deinit(gpa);
+                                    while (snapshot.pumpHistory(gpa, &mut_res.decoder, &restored_term) catch false) {}
+                                    if (util.serializeTerminalState(gpa, &restored_term)) |term_output| {
+                                        defer gpa.free(term_output);
+                                        const restore_data = util.rewritePromptRedraw(gpa, term_output) orelse term_output;
+                                        defer if (restore_data.ptr != term_output.ptr) gpa.free(restore_data);
+                                        try stdout_buf.appendSlice(gpa, restore_data);
+                                    }
+                                } else |err| {
+                                    std.log.warn("failed to import snapshot in client err={s}", .{@errorName(err)});
+                                }
+                            }
                         }
                     },
                     .Resize => {
@@ -469,7 +501,7 @@ fn daemonLoop(daemon: *Daemon, gpa: std.mem.Allocator, io: std.Io, server_sock_f
                         .Input => try daemon.handleInput(gpa, client, msg.payload),
                         .Send => daemon.handleSend(gpa, msg.payload),
                         .Output => try daemon.handleOutput(gpa, msg.payload, &term, &vt_stream),
-                        .Init => try daemon.handleInit(gpa, client, pty_fd, &term, msg.payload),
+                        .Init => try daemon.handleInit(gpa, io, client, pty_fd, &term, msg.payload),
                         .Switch => try daemon.handleSwitch(gpa, msg.payload),
                         .Resize => try daemon.handleResize(gpa, client, pty_fd, &term, msg.payload),
                         .Detach => {
@@ -491,7 +523,7 @@ fn daemonLoop(daemon: *Daemon, gpa: std.mem.Allocator, io: std.Io, server_sock_f
                         .EnvSet => try daemon.handleEnvSet(gpa, client, msg.payload),
                         .History => try daemon.handleHistory(gpa, client, &term, msg.payload),
                         .Run => try daemon.handleRun(gpa, io, client, msg.payload),
-                        .Ack, .TaskComplete, .LabelData, .EnvData => {},
+                        .Ack, .TaskComplete, .LabelData, .EnvData, .Snapshot => {},
                         .Write => try daemon.handleWrite(gpa, client, msg.payload),
                         _ => std.log.warn(
                             "ignoring unknown IPC tag={d}",
@@ -950,31 +982,61 @@ pub const Daemon = struct {
     pub fn handleInit(
         self: *Daemon,
         gpa: std.mem.Allocator,
+        io: std.Io,
         client: *Client,
         pty_fd: i32,
         term: *ghostty_vt.Terminal,
         payload: []const u8,
     ) !void {
-        if (payload.len != @sizeOf(ipc.Resize)) return;
-
         client.is_terminal = true;
 
         if (self.leader_client_fd == null) {
             try self.setLeader(gpa, client);
         }
         const is_leader = self.leader_client_fd == client.socket_fd;
-        const resize = std.mem.bytesToValue(ipc.Resize, payload);
 
-        // Resize our terminal (not yet the PTY) to the leader's size before
-        // serializing, so the snapshot is laid out for the width the client
-        // will render it at instead of being wrapped a second time on arrival.
-        // Cursor position stays consistent because it is serialized from the
-        // same, already-resized terminal; the PTY is resized below, so the
-        // shell's own SIGWINCH redraw still arrives after the snapshot.
-        if (is_leader) {
-            try resizeTerm(gpa, term, resize.cols, resize.rows);
+        var rows: u16 = 24;
+        var cols: u16 = 80;
+        var xpixel: u16 = 0;
+        var ypixel: u16 = 0;
+
+        if (payload.len == @sizeOf(ipc.Resize)) {
+            const resize = std.mem.bytesToValue(ipc.Resize, payload);
+            rows = resize.rows;
+            cols = resize.cols;
+            xpixel = resize.xpixel;
+            ypixel = resize.ypixel;
+        } else {
+            var reader: std.Io.Reader = .fixed(payload);
+            if (snapshot.startImport(gpa, io, &reader, 1024 * 1024)) |import_res| {
+                var mut_res = import_res;
+                defer mut_res.deinit(gpa);
+                var imported_term = mut_res.terminal;
+                defer imported_term.deinit(gpa);
+
+                rows = imported_term.rows;
+                cols = imported_term.cols;
+                xpixel = @as(u16, @intCast(@min(std.math.maxInt(u16), imported_term.width_px)));
+                ypixel = @as(u16, @intCast(@min(std.math.maxInt(u16), imported_term.height_px)));
+
+                // First client attaching seeds the base session theme, cursor style/blink, modes, and pixel geometry
+                if (!self.has_had_client) {
+                    term.colors = imported_term.colors;
+                    term.screens.active.cursor.cursor_style = imported_term.screens.active.cursor.cursor_style;
+                    term.screens.active.kitty_keyboard = imported_term.screens.active.kitty_keyboard;
+                    term.modes = imported_term.modes;
+                    term.width_px = imported_term.width_px;
+                    term.height_px = imported_term.height_px;
+                }
+            } else |err| {
+                std.log.warn("failed to import client init snapshot err={s}", .{@errorName(err)});
+                return;
+            }
         }
 
+        // Export terminal snapshot BEFORE resize to capture correct cursor position.
+        // Resizing triggers reflow which can move the cursor, and the shell's
+        // SIGWINCH-triggered redraw will run after our snapshot is sent.
         // Only serialize on re-attach (has_had_client), not first attach, to avoid
         // interfering with shell initialization (DA1 queries, etc.)
         if (self.has_pty_output and self.has_had_client) {
@@ -983,16 +1045,16 @@ pub const Daemon = struct {
                 "cursor before serialize: x={d} y={d} pending_wrap={}",
                 .{ cursor.x, cursor.y, cursor.pending_wrap },
             );
-            if (util.serializeTerminalState(gpa, term)) |term_output| {
-                std.log.debug("serialize terminal state", .{});
-                // Rewrite OSC 133;A to include redraw=0 so the outer terminal
-                // does not clear prompt lines on resize (issue #111).
-                const restore_data = util.rewritePromptRedraw(gpa, term_output) orelse term_output;
-                defer gpa.free(term_output);
-                defer if (restore_data.ptr != term_output.ptr) gpa.free(restore_data);
-                ipc.appendMessage(gpa, &client.write_buf, .Output, restore_data) catch |err| {
+            var snap_buf: std.Io.Writer.Allocating = .init(gpa);
+            defer snap_buf.deinit();
+            snapshot.exportSnapshot(gpa, &snap_buf.writer, term, .{}) catch |err| {
+                std.log.warn("failed to export snapshot err={s}", .{@errorName(err)});
+            };
+            if (snap_buf.written().len > 0) {
+                std.log.debug("serialize terminal snapshot bytes={d}", .{snap_buf.written().len});
+                ipc.appendMessage(gpa, &client.write_buf, .Snapshot, snap_buf.written()) catch |err| {
                     std.log.warn(
-                        "failed to buffer terminal state for client err={s}",
+                        "failed to buffer snapshot for client err={s}",
                         .{@errorName(err)},
                     );
                 };
@@ -1002,7 +1064,12 @@ pub const Daemon = struct {
 
         // only resize if leader
         if (is_leader) {
-            var ws = resize.winsize();
+            var ws: cross.c.struct_winsize = .{
+                .ws_row = rows,
+                .ws_col = cols,
+                .ws_xpixel = xpixel,
+                .ws_ypixel = ypixel,
+            };
             _ = cross.c.ioctl(pty_fd, cross.c.TIOCSWINSZ, &ws);
 
             // On re-attach, deliver SIGWINCH to the foreground process group so
@@ -1016,10 +1083,23 @@ pub const Daemon = struct {
                 }
             }
 
+            // Disable prompt_redraw before resize. The daemon's internal terminal
+            // would otherwise clear prompt lines expecting the shell to redraw them,
+            // but the shell's redraw goes to the PTY (forwarded to clients), not to
+            // this daemon terminal. The clearing corrupts the daemon's snapshot state.
+            const saved_prompt_redraw = term.flags.shell_redraws_prompt;
+            term.flags.shell_redraws_prompt = .false;
+            defer term.flags.shell_redraws_prompt = saved_prompt_redraw;
+            const opts = ghostty_vt.Terminal.Resize{
+                .cols = cols,
+                .rows = rows,
+            };
+            try term.resize(gpa, opts);
+
             // Mark that we've had a client init, so subsequent clients get terminal state
             self.has_had_client = true;
 
-            std.log.debug("init resize rows={d} cols={d}", .{ resize.rows, resize.cols });
+            std.log.debug("init resize rows={d} cols={d}", .{ rows, cols });
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -15,6 +15,7 @@ const Cfg = @import("cfg.zig");
 const loop = @import("loop.zig");
 const Client = loop.Client;
 const Daemon = loop.Daemon;
+const probe = @import("probe.zig");
 const version = build_options.version;
 const ghostty_version = build_options.ghostty_version;
 
@@ -161,12 +162,11 @@ pub fn main(init: std.process.Init) !void {
         daemon.setCwd(cwd);
         daemon.shell = shell_env;
         std.log.info("socket path={s}", .{daemon.socket_path});
-
         const env_keys = lib_posix.getenv("ZMX_TRACK_ENV") orelse cfg.tracked_envs;
         const env_str = try getTrackedEnvStr(gpa, env_keys, init.environ_map);
         defer gpa.free(env_str);
 
-        return attach(gpa, io, &daemon, env_str, parsed.labels);
+        return attach(gpa, io, &daemon, env_str, parsed.labels, parsed.snapshot_mode);
     } else if (std.mem.eql(u8, cmd, "run") or std.mem.eql(u8, cmd, "r")) {
         const session_name = args.next() orelse "";
         if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
@@ -447,7 +447,7 @@ fn help(io: std.Io) !void {
         \\Usage: zmx <command> [args...]
         \\
         \\Commands:
-        \\  [a]ttach [--labels kv] <name> [command...]  Attach to session, creating if needed
+        \\  [a]ttach [-s|--snapshot] [--labels kv] <name> [command...] Attach to session, creating if needed
         \\  [r]un <name> [-d] [command...]              Send command without attaching
         \\  [s]end <name> <text...>                     Send raw input to session PTY
         \\  [p]rint <name> <text...>                    Inject text into session display
@@ -476,6 +476,7 @@ fn help(io: std.Io) !void {
         \\
         \\  Examples:
         \\    zmx attach dev
+        \\    zmx attach --snapshot dev
         \\    zmx attach dev vim
         \\    zmx attach --labels "project=api role=worker" build
         \\
@@ -1488,6 +1489,7 @@ const AttachArgs = struct {
     /// `--labels "k=v ..."`: labels to apply once the session exists, in the
     /// same space-separated form `zmx set` takes.
     labels: ?[]const u8 = null,
+    snapshot_mode: bool = false,
     want_help: bool = false,
     /// `--labels` was given with nothing to apply.
     missing_labels_value: bool = false,
@@ -1505,6 +1507,10 @@ fn parseAttachArgs(argv: []const []const u8) AttachArgs {
         if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
             parsed.want_help = true;
             return parsed;
+        }
+        if (std.mem.eql(u8, arg, "--snapshot") or std.mem.eql(u8, arg, "-s")) {
+            parsed.snapshot_mode = true;
+            continue;
         }
         if (std.mem.startsWith(u8, arg, labels_flag ++ "=")) {
             parsed.labels = arg[labels_flag.len + 1 ..];
@@ -1528,7 +1534,7 @@ fn parseAttachArgs(argv: []const []const u8) AttachArgs {
     return parsed;
 }
 
-fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, env_str: []const u8, labels: ?[]const u8) !void {
+fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, env_str: []const u8, labels: ?[]const u8, snapshot_mode: bool) !void {
     const sesh = socket.getSeshNameFromEnv();
     if (sesh.len > 0) {
         return switchSesh(gpa, io, daemon, sesh);
@@ -1559,7 +1565,7 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, env_str: []const 
     // skip terminal setup entirely rather than applying undefined stack bytes
     // via tcsetattr.
     var orig_termios: cross.c.termios = undefined;
-    const stdin_is_tty = cross.c.tcgetattr(lib_posix.STDIN_FILENO, &orig_termios) == 0;
+    const stdin_is_tty = !snapshot_mode and cross.c.tcgetattr(lib_posix.STDIN_FILENO, &orig_termios) == 0;
 
     // RIS, OSC 10/11/12
     const restore_seq = "\x1bc\x1b]110\x1b\\\x1b]111\x1b\\\x1b]112\x1b\\";
@@ -1568,8 +1574,10 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, env_str: []const 
         if (stdin_is_tty) {
             _ = cross.c.tcsetattr(lib_posix.STDIN_FILENO, cross.c.TCSAFLUSH, &orig_termios);
         }
-        // Reset terminal modes on detach
-        _ = lib_posix.write(lib_posix.STDOUT_FILENO, restore_seq) catch {};
+        if (!snapshot_mode) {
+            // Reset terminal modes on detach
+            _ = lib_posix.write(lib_posix.STDOUT_FILENO, restore_seq) catch {};
+        }
     }
 
     if (stdin_is_tty) {
@@ -1590,18 +1598,36 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, env_str: []const 
         _ = cross.c.tcsetattr(lib_posix.STDIN_FILENO, cross.c.TCSANOW, &raw_termios);
     }
 
-    // Clear screen before attaching. This provides a clean slate before
-    // the session restore.
-    const clear_seq = "\x1b[2J\x1b[H";
-    _ = try lib_posix.write(lib_posix.STDOUT_FILENO, clear_seq);
+    // Probe outer terminal (if TTY) and create init snapshot
+    const size = ipc.getTerminalSize(lib_posix.STDOUT_FILENO);
+    const init_snap = try probe.probeAndSnapshot(
+        io,
+        gpa,
+        size.rows,
+        size.cols,
+        size.xpixel,
+        size.ypixel,
+        stdin_is_tty,
+        probe.DEFAULT_PROBE_TIMEOUT_MS,
+    );
+    defer gpa.free(init_snap);
 
-    const looper = try loop.clientLoop(client_sock, env_str);
+    if (!snapshot_mode) {
+        // Clear screen before attaching. This provides a clean slate before
+        // the session restore.
+        const clear_seq = "\x1b[2J\x1b[H";
+        _ = try lib_posix.write(lib_posix.STDOUT_FILENO, clear_seq);
+    }
+
+    const looper = try loop.clientLoop(io, client_sock, snapshot_mode, init_snap, env_str);
     switch (looper.kind) {
         .detach => return,
         .switch_session => {
             if (looper.session_name) |session_name| {
-                // Reset terminal modes when switching sessions
-                _ = lib_posix.write(lib_posix.STDOUT_FILENO, restore_seq) catch {};
+                if (!snapshot_mode) {
+                    // Reset terminal modes when switching sessions
+                    _ = lib_posix.write(lib_posix.STDOUT_FILENO, restore_seq) catch {};
+                }
 
                 const target_path = socket.getSocketPath(
                     gpa,
@@ -1623,7 +1649,7 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, env_str: []const 
                 std.log.info("switching to new session cwd={s}", .{switch_cwd});
                 target_daemon.setCwd(switch_cwd);
                 target_daemon.shell = daemon.shell;
-                return attach(gpa, io, &target_daemon, env_str, null);
+                return attach(gpa, io, &target_daemon, env_str, null, snapshot_mode);
             }
         },
     }
@@ -1921,7 +1947,6 @@ test "parseAttachArgs leaves labels unset when the flag is absent" {
     try std.testing.expectEqual(@as(?[]const u8, null), parsed.labels);
     try std.testing.expect(!parsed.missing_labels_value);
 }
-
 test "getTrackedEnvStr includes set and unset entries" {
     const alloc = std.testing.allocator;
     var env_map = std.process.Environ.Map.init(alloc);
@@ -1962,4 +1987,18 @@ test "EnvIterator parses set and unset entries correctly" {
     try std.testing.expectEqualStrings("/tmp/ssh.sock", e3.value.?);
 
     try std.testing.expect(it.next() == null);
+}
+
+test "parseAttachArgs reads snapshot flag" {
+    for ([_][]const []const u8{
+        &.{ "--snapshot", "dev" },
+        &.{ "-s", "dev" },
+        &.{ "--snapshot", "--labels", "k=v", "dev" },
+    }) |argv| {
+        const parsed = parseAttachArgs(argv);
+        try std.testing.expect(parsed.snapshot_mode);
+        try std.testing.expectEqualStrings("dev", parsed.session_name);
+    }
+    const parsed = parseAttachArgs(&.{"dev"});
+    try std.testing.expect(!parsed.snapshot_mode);
 }

--- a/src/probe.zig
+++ b/src/probe.zig
@@ -1,0 +1,324 @@
+//! Outer terminal probing and snapshot generation for zmx.
+//!
+//! Synchronizes the outer terminal emulator's configuration (colors, palette,
+//! cursor style, blinking, pixel geometry, protocol capabilities, and DEC modes
+//! such as in-band size reports) into a binary Snapshot buffer.
+
+const std = @import("std");
+const ghostty_vt = @import("ghostty-vt");
+const lib_posix = @import("posix.zig");
+const cross = @import("cross.zig");
+const ipc = @import("ipc.zig");
+const snapshot = @import("snapshot.zig");
+const Allocator = std.mem.Allocator;
+
+/// Escape sequences sent to probe the outer terminal.
+///
+/// Combines:
+/// - Dynamic colors: OSC 10 (fg), OSC 11 (bg), OSC 12 (cursor)
+/// - 16-color ANSI palette: OSC 4 (0..15)
+/// - Cursor shape: DECSCUSR query (\x1b[? q)
+/// - Cursor blinking: DECRQM mode 12 (\x1b[?12$p)
+/// - In-band size reports: DECRQM mode 2048 (\x1b[?2048$p)
+/// - Color scheme / dark-light mode: DECRQM mode 2031 (\x1b[?2031$p)
+/// - Pixel geometry: XTWINOPS text area (\x1b[14t)
+/// - Kitty keyboard protocol query (\x1b[?u)
+pub const PROBE_QUERY =
+    "\x1b]10;?\x07" ++
+    "\x1b]11;?\x07" ++
+    "\x1b]12;?\x07" ++
+    "\x1b]4;0;?;1;?;2;?;3;?;4;?;5;?;6;?;7;?;8;?;9;?;10;?;11;?;12;?;13;?;14;?;15;?\x07" ++
+    "\x1b[? q" ++
+    "\x1b[?12$p" ++
+    "\x1b[?2048$p" ++
+    "\x1b[?2031$p" ++
+    "\x1b[14t" ++
+    "\x1b[?u";
+
+/// Default probe timeout in milliseconds for local TTYs.
+pub const DEFAULT_PROBE_TIMEOUT_MS: u32 = 40;
+
+fn getMonotonicNs() i128 {
+    var ts: cross.c.struct_timespec = undefined;
+    _ = cross.c.clock_gettime(cross.c.CLOCK_MONOTONIC, &ts);
+    return @as(i128, ts.tv_sec) * std.time.ns_per_s + ts.tv_nsec;
+}
+
+/// Drains probe responses from tty_in_fd into the terminal's vtStream.
+pub fn probeOuterTerminal(
+    tty_out_fd: i32,
+    tty_in_fd: i32,
+    timeout_ms: u32,
+    term: *ghostty_vt.Terminal,
+) !void {
+    _ = lib_posix.write(tty_out_fd, PROBE_QUERY) catch return;
+
+    var vt_stream = term.vtStream();
+    defer vt_stream.deinit();
+
+    var poll_fds = [_]lib_posix.pollfd{.{
+        .fd = tty_in_fd,
+        .events = lib_posix.POLL.IN,
+        .revents = 0,
+    }};
+
+    const start_ns = getMonotonicNs();
+    const timeout_ns = @as(i128, timeout_ms) * std.time.ns_per_ms;
+
+    var buf: [4096]u8 = undefined;
+
+    while (true) {
+        const elapsed_ns = getMonotonicNs() - start_ns;
+        if (elapsed_ns >= timeout_ns) break;
+        const remaining_ms = @as(i32, @intCast(@min(50, @divTrunc(timeout_ns - elapsed_ns, std.time.ns_per_ms))));
+        if (remaining_ms <= 0) break;
+
+        const poll_res = lib_posix.poll(&poll_fds, remaining_ms) catch break;
+        if (poll_res == 0) break; // Timeout on slice
+
+        if (poll_fds[0].revents & lib_posix.POLL.IN != 0) {
+            const n = lib_posix.read(tty_in_fd, &buf) catch |err| {
+                if (err == error.WouldBlock) continue;
+                break;
+            };
+            if (n == 0) break;
+
+            const slice = buf[0..n];
+            applyProbeChunk(term, &vt_stream, slice);
+        } else {
+            break;
+        }
+    }
+}
+
+/// Ingest a slice of probe response bytes into the terminal and handle any non-OSC
+/// response side-effects (DECRPM, XTWINOPS, Kitty keyboard).
+pub fn applyProbeChunk(
+    term: *ghostty_vt.Terminal,
+    vt_stream: *ghostty_vt.TerminalStream,
+    slice: []const u8,
+) void {
+    // Feed through Ghostty VT stream to parse OSC 4/10/11/12, DECSCUSR, etc.
+    vt_stream.nextSlice(slice);
+
+    // Parse DECRPM responses: \x1b[?<mode>;<status>$y (DEC) or \x1b[<mode>;<status>$y (ANSI)
+    var decrpm_idx: usize = 0;
+    while (std.mem.indexOfPos(u8, slice, decrpm_idx, "\x1b[")) |start_idx| {
+        const rest = slice[start_idx + 2 ..];
+        if (std.mem.indexOf(u8, rest, "$y")) |y_rel| {
+            const report_str = rest[0..y_rel];
+            const is_dec = report_str.len > 0 and report_str[0] == '?';
+            const num_str = if (is_dec) report_str[1..] else report_str;
+            if (std.mem.indexOfScalar(u8, num_str, ';')) |semi_rel| {
+                const mode_raw = num_str[0..semi_rel];
+                const status_raw = num_str[semi_rel + 1 ..];
+                const mode_num = std.fmt.parseInt(u16, mode_raw, 10) catch 0;
+                const status = std.fmt.parseInt(u8, status_raw, 10) catch 0;
+                if (ghostty_vt.modes.modeFromInt(mode_num, !is_dec)) |mode| {
+                    if (status == 1) {
+                        term.modes.set(mode, true);
+                    } else if (status == 2) {
+                        term.modes.set(mode, false);
+                    }
+                }
+            }
+            decrpm_idx = start_idx + 2 + y_rel + 2;
+        } else {
+            break;
+        }
+    }
+
+    // Parse XTWINOPS response: \x1b[4;<height>;<width>t
+    var search_idx: usize = 0;
+    while (std.mem.indexOfPos(u8, slice, search_idx, "\x1b[4;")) |start_idx| {
+        const rest = slice[start_idx + 4 ..];
+        if (std.mem.indexOfScalar(u8, rest, 't')) |end_rel| {
+            const param_str = rest[0..end_rel];
+            if (std.mem.indexOfScalar(u8, param_str, ';')) |semi_idx| {
+                const h_str = param_str[0..semi_idx];
+                const w_str = param_str[semi_idx + 1 ..];
+                const h = std.fmt.parseInt(u32, h_str, 10) catch 0;
+                const w = std.fmt.parseInt(u32, w_str, 10) catch 0;
+                if (h > 0 and w > 0) {
+                    term.height_px = h;
+                    term.width_px = w;
+                }
+            }
+            search_idx = start_idx + 4 + end_rel + 1;
+        } else {
+            break;
+        }
+    }
+
+    // Parse Kitty keyboard query response: \x1b[?<flags>u
+    var kb_search_idx: usize = 0;
+    while (std.mem.indexOfPos(u8, slice, kb_search_idx, "\x1b[?")) |start_idx| {
+        const rest = slice[start_idx + 3 ..];
+        if (std.mem.indexOfScalar(u8, rest, 'u')) |end_rel| {
+            const flag_str = rest[0..end_rel];
+            if (std.fmt.parseInt(u5, flag_str, 10)) |flag_val| {
+                term.screens.active.kitty_keyboard.set(
+                    .set,
+                    @as(ghostty_vt.kitty.KeyFlags, @bitCast(flag_val)),
+                );
+            } else |_| {}
+            kb_search_idx = start_idx + 3 + end_rel + 1;
+        } else {
+            break;
+        }
+    }
+}
+
+/// Probes outer terminal if in TTY mode and encodes a binary Snapshot buffer.
+pub fn probeAndSnapshot(
+    io: std.Io,
+    alloc: Allocator,
+    rows: u16,
+    cols: u16,
+    xpixel: u16,
+    ypixel: u16,
+    is_tty: bool,
+    timeout_ms: u32,
+) ![]u8 {
+    var term = try ghostty_vt.Terminal.init(io, alloc, .{
+        .cols = cols,
+        .rows = rows,
+    });
+    defer term.deinit(alloc);
+
+    term.width_px = xpixel;
+    term.height_px = ypixel;
+
+    if (is_tty) {
+        probeOuterTerminal(
+            lib_posix.STDOUT_FILENO,
+            lib_posix.STDIN_FILENO,
+            timeout_ms,
+            &term,
+        ) catch |err| {
+            std.log.debug("probe outer terminal failed: {s}", .{@errorName(err)});
+        };
+    }
+
+    var snap_buf: std.Io.Writer.Allocating = .init(alloc);
+    defer snap_buf.deinit();
+
+    try snapshot.exportSnapshot(alloc, &snap_buf.writer, &term, .{});
+    return alloc.dupe(u8, snap_buf.written());
+}
+
+test "applyProbeChunk parses OSC colors, dec modes, and kitty protocols" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var term = try ghostty_vt.Terminal.init(testing.io, alloc, .{ .cols = 80, .rows = 24 });
+    defer term.deinit(alloc);
+
+    var vt_stream = term.vtStream();
+    defer vt_stream.deinit();
+
+    // Responses from outer terminal
+    const osc_fg = "\x1b]10;rgb:c0c0/caf5/f5f5\x1b\\";
+    const osc_bg = "\x1b]11;rgb:1a1a/1b1b/2626\x1b\\";
+    const osc_cursor = "\x1b]12;rgb:ffff/aaaa/5555\x07";
+    const osc_palette = "\x1b]4;0;rgb:1515/1616/1e1e;1;rgb:f7f7/7676/8e8e\x1b\\";
+    const decscusr = "\x1b[5 q"; // Blinking bar
+    const dec_in_band = "\x1b[?2048;1$y"; // In-band size reports enabled
+    const dec_color_scheme = "\x1b[?2031;1$y"; // Report color scheme enabled
+    const xtwinops = "\x1b[4;900;1440t";
+    const kitty_kb = "\x1b[?1u";
+    const kitty_gfx = "\x1b_Gi=1;OK\x1b\\";
+
+    applyProbeChunk(&term, &vt_stream, osc_fg);
+    applyProbeChunk(&term, &vt_stream, osc_bg);
+    applyProbeChunk(&term, &vt_stream, osc_cursor);
+    applyProbeChunk(&term, &vt_stream, osc_palette);
+    applyProbeChunk(&term, &vt_stream, decscusr);
+    applyProbeChunk(&term, &vt_stream, dec_in_band);
+    applyProbeChunk(&term, &vt_stream, dec_color_scheme);
+    applyProbeChunk(&term, &vt_stream, xtwinops);
+    applyProbeChunk(&term, &vt_stream, kitty_kb);
+    applyProbeChunk(&term, &vt_stream, kitty_gfx);
+
+    const fg = term.colors.foreground.get().?;
+    try testing.expectEqual(@as(u8, 0xc0), fg.r);
+    try testing.expectEqual(@as(u8, 0xca), fg.g);
+    try testing.expectEqual(@as(u8, 0xf5), fg.b);
+
+    const bg = term.colors.background.get().?;
+    try testing.expectEqual(@as(u8, 0x1a), bg.r);
+    try testing.expectEqual(@as(u8, 0x1b), bg.g);
+    try testing.expectEqual(@as(u8, 0x26), bg.b);
+
+    const cursor = term.colors.cursor.get().?;
+    try testing.expectEqual(@as(u8, 0xff), cursor.r);
+    try testing.expectEqual(@as(u8, 0xaa), cursor.g);
+    try testing.expectEqual(@as(u8, 0x55), cursor.b);
+
+    const p0 = term.colors.palette.current[0];
+    try testing.expectEqual(@as(u8, 0x15), p0.r);
+    try testing.expectEqual(@as(u8, 0x16), p0.g);
+    try testing.expectEqual(@as(u8, 0x1e), p0.b);
+
+    const p1 = term.colors.palette.current[1];
+    try testing.expectEqual(@as(u8, 0xf7), p1.r);
+    try testing.expectEqual(@as(u8, 0x76), p1.g);
+    try testing.expectEqual(@as(u8, 0x8e), p1.b);
+
+    try testing.expectEqual(ghostty_vt.Screen.CursorStyle.bar, term.screens.active.cursor.cursor_style);
+    try testing.expect(term.modes.get(.cursor_blinking));
+    try testing.expect(term.modes.get(.in_band_size_reports));
+    try testing.expect(term.modes.get(.report_color_scheme));
+    try testing.expectEqual(@as(u32, 1440), term.width_px);
+    try testing.expectEqual(@as(u32, 900), term.height_px);
+    try testing.expectEqual(@as(u8, 1), term.screens.active.kitty_keyboard.current().int());
+}
+
+test "probe snapshot roundtrip preserves probed state and modes" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var term = try ghostty_vt.Terminal.init(testing.io, alloc, .{ .cols = 100, .rows = 30 });
+    defer term.deinit(alloc);
+
+    var vt_stream = term.vtStream();
+    defer vt_stream.deinit();
+
+    applyProbeChunk(&term, &vt_stream, "\x1b]10;rgb:aabb/ccdd/eeff\x1b\\");
+    applyProbeChunk(&term, &vt_stream, "\x1b]11;rgb:1122/3344/5566\x1b\\");
+    applyProbeChunk(&term, &vt_stream, "\x1b[3 q"); // Blinking underline
+    applyProbeChunk(&term, &vt_stream, "\x1b[?2048;1$y"); // In-band size reports
+    applyProbeChunk(&term, &vt_stream, "\x1b[4;600;800t");
+    applyProbeChunk(&term, &vt_stream, "\x1b[?3u"); // Kitty keyboard flags = 3
+
+    var snap_buf: std.Io.Writer.Allocating = .init(alloc);
+    defer snap_buf.deinit();
+    try snapshot.exportSnapshot(alloc, &snap_buf.writer, &term, .{});
+
+    var reader: std.Io.Reader = .fixed(snap_buf.written());
+    var import_res = try snapshot.startImport(alloc, testing.io, &reader, 1024 * 1024);
+    defer import_res.deinit(alloc);
+
+    var restored = import_res.terminal;
+    defer restored.deinit(alloc);
+
+    try testing.expectEqual(@as(u16, 100), restored.cols);
+    try testing.expectEqual(@as(u16, 30), restored.rows);
+    try testing.expectEqual(@as(u32, 800), restored.width_px);
+    try testing.expectEqual(@as(u32, 600), restored.height_px);
+
+    const fg = restored.colors.foreground.get().?;
+    try testing.expectEqual(@as(u8, 0xaa), fg.r);
+    try testing.expectEqual(@as(u8, 0xcc), fg.g);
+    try testing.expectEqual(@as(u8, 0xee), fg.b);
+
+    const bg = restored.colors.background.get().?;
+    try testing.expectEqual(@as(u8, 0x11), bg.r);
+    try testing.expectEqual(@as(u8, 0x33), bg.g);
+    try testing.expectEqual(@as(u8, 0x55), bg.b);
+
+    try testing.expectEqual(ghostty_vt.Screen.CursorStyle.underline, restored.screens.active.cursor.cursor_style);
+    try testing.expect(restored.modes.get(.cursor_blinking));
+    try testing.expect(restored.modes.get(.in_band_size_reports));
+    try testing.expectEqual(@as(u8, 3), restored.screens.active.kitty_keyboard.current().int());
+}

--- a/src/snapshot.zig
+++ b/src/snapshot.zig
@@ -1,0 +1,105 @@
+//! Terminal binary snapshot encode and decode helpers for zmx.
+
+const std = @import("std");
+const ghostty_vt = @import("ghostty-vt");
+const Allocator = std.mem.Allocator;
+
+pub const Continuation = ghostty_vt.snapshot.Continuation;
+pub const EncodeOptions = ghostty_vt.snapshot.EncodeOptions;
+pub const DecodeOptions = ghostty_vt.snapshot.DecodeOptions;
+pub const Decoded = ghostty_vt.snapshot.Decoded;
+pub const Decoder = ghostty_vt.snapshot.Decoder;
+
+pub const ExportOptions = struct {
+    continuation: Continuation = .ground,
+};
+
+pub const ImportResult = struct {
+    terminal: ghostty_vt.Terminal,
+    continuation: Continuation,
+    history_rows: std.EnumMap(ghostty_vt.ScreenSet.Key, u64),
+    decoder: Decoder,
+
+    pub fn deinit(self: *ImportResult, alloc: Allocator) void {
+        switch (self.continuation) {
+            .ground => {},
+            .bytes => |bytes| alloc.free(bytes),
+        }
+        self.* = undefined;
+    }
+};
+
+/// Encode a complete terminal snapshot into any writer.
+pub fn exportSnapshot(
+    alloc: Allocator,
+    destination: *std.Io.Writer,
+    terminal: *const ghostty_vt.Terminal,
+    options: ExportOptions,
+) ghostty_vt.snapshot.EncodeError!void {
+    try ghostty_vt.snapshot.encode(alloc, destination, terminal, .{
+        .continuation = options.continuation,
+    });
+}
+
+/// Begin decoding from a stream or pipe.
+pub fn startImport(
+    alloc: Allocator,
+    io: std.Io,
+    reader: *std.Io.Reader,
+    max_continuation_bytes: usize,
+) Decoder.ReadyError!ImportResult {
+    var decoder = Decoder.init(reader);
+    var decoded = try decoder.ready(alloc, io, .{
+        .max_continuation_bytes = max_continuation_bytes,
+    });
+    errdefer decoded.deinit(alloc);
+
+    return .{
+        .terminal = decoded.toOwned(),
+        .continuation = decoded.continuation,
+        .history_rows = decoded.history_rows,
+        .decoder = decoder,
+    };
+}
+
+/// Incrementally pump scrollback history pages until FINISH is reached.
+pub fn pumpHistory(
+    alloc: Allocator,
+    decoder: *Decoder,
+    terminal: *ghostty_vt.Terminal,
+) Decoder.NextError!bool {
+    if (try decoder.next(alloc, terminal)) |_| {
+        return true;
+    }
+    return false;
+}
+
+test "snapshot export and import roundtrip" {
+    const testing = std.testing;
+    const alloc = testing.allocator;
+
+    var term: ghostty_vt.Terminal = try .init(testing.io, alloc, .{ .cols = 40, .rows = 10 });
+    defer term.deinit(alloc);
+
+    var stream = term.vtStream();
+    defer stream.deinit();
+    stream.nextSlice("Hello from ZMX Snapshot!\r\nLine 2");
+
+    var buffer: std.Io.Writer.Allocating = .init(alloc);
+    defer buffer.deinit();
+
+    try exportSnapshot(alloc, &buffer.writer, &term, .{});
+
+    var reader: std.Io.Reader = .fixed(buffer.written());
+    var import_res = try startImport(alloc, testing.io, &reader, 64 * 1024);
+    defer import_res.deinit(alloc);
+
+    var restored = import_res.terminal;
+    defer restored.deinit(alloc);
+
+    try testing.expectEqual(@as(u16, 40), restored.cols);
+    try testing.expectEqual(@as(u16, 10), restored.rows);
+
+    const has_more = try pumpHistory(alloc, &import_res.decoder, &restored);
+    try testing.expect(!has_more);
+}

--- a/src/test.zig
+++ b/src/test.zig
@@ -8,4 +8,6 @@ comptime {
     _ = @import("loop.zig");
     _ = @import("cfg.zig");
     _ = @import("daemonize.zig");
+    _ = @import("snapshot.zig");
+    _ = @import("probe.zig");
 }


### PR DESCRIPTION
This allows zmx to directly inject terminal state into terminal emulators that speak libghostty's snapshot api.

This only impacts terminal rehydration of clients when they first attach to a zmx session.

What does this mean?

Terminal emulators that support loading libghostty snapshots directly can receive a perfect recreation of zmx's session instead of relying on us re-printing the ansi bytestream into every client that connects to a zmx session.  Printing the bytestream mostly works but has some weird quirks and is not guaranteed to be identical -- it's an approximation.  Using the snapshot API we get a much closer terminal "cloning" system.

Right now only `monstar` has experimental support for the snapshot api, but this is how it would work:

```bash
zmx attach snap.1
# do some terminal stuff
# close terminal and then use monstar:
monstar --attach="zmx attach -s snap.1"
# zmx will directly load the underlying `libghostty.Terminal` into `monstar`
```

Link: https://github.com/rockorager/monstar/pull/35