### PR TITLE
feat: leader sets tracked env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Use spec: https://common-changelog.org/
 - Added `--labels` flag to attach command
   - e.g. `zmx attach --labels "project=pico env=prod" pico`
   - e.g. `zmx attach --labels "$(zmx get pico)" pico.sub`
+- New command `zmx print-env` which prints the leader's tracked env vars
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Commands:
   [l]ist|ls [--short|--where k=v]          List active sessions
   [g]et <name>                             Get session labels
   set <name> k=v ...                       Set session labels
-  [un]set <name> key ...                   Remove session labels
   [cl]ear <name>                           Clear all session labels
+  print-env [name] [key]                   Print tracked environment variables
   [k]ill <name>... [--force]               Kill session and all attached clients
   [hi]story <name> [--vt|--html]           Output session scrollback
   [w]ait <name>...                         Wait for session tasks to complete
@@ -123,14 +123,9 @@ Commands:
 
 ## nested sessions
 
-Nested sessions are not supported. Inside a session `ZMX_SESSION` is set, and
-`attach` reads it: instead of creating another client it switches the calling
-terminal to the session you named.
+Nested sessions are not supported. Inside a session `ZMX_SESSION` is set, and `attach` reads it: instead of creating another client it switches the calling terminal to the session you named.
 
-That matters when the variable is inherited rather than chosen. A script, build
-tool, or coding agent started inside a session runs with `ZMX_SESSION` set, so
-`zmx attach other` from there moves the terminal somebody was using, and the
-session it was showing is left with no client.
+That matters when the variable is inherited rather than chosen. A script, build tool, or coding agent started inside a session runs with `ZMX_SESSION` set, so `zmx attach other` from there moves the terminal somebody was using, and the session it was showing is left with no client.
 
 Unset it in anything that attaches on its own behalf:
 
@@ -214,6 +209,81 @@ symbol = " "
 format = "[$symbol$env_value]($style) "
 description = "zmx session name"
 style = "bold magenta"
+```
+
+## environment variables
+
+A session's environment is initialized when the session is created. When re-attaching from a new terminal or a different SSH connection, environment variables describing the client connection (such as `SSH_AUTH_SOCK`, `DISPLAY`, or terminal remote control variables like `KITTY_LISTEN_ON`, `KITTY_PID`, `KITTY_WINDOW_ID`) become outdated in the running shell.
+
+`zmx` tracks these environment variables from attaching clients. You can inspect the current leader client's environment with `zmx print-env`:
+
+```bash
+# Print all tracked environment variables as KEY=VALUE
+zmx print-env
+
+# Print a specific variable value
+zmx print-env . SSH_AUTH_SOCK
+```
+
+You can automatically update your shell environment before each prompt:
+
+### bash
+
+Add to `~/.bashrc`:
+
+```bash
+_zmx_env_hook() {
+  if [[ -n $ZMX_SESSION ]]; then
+    eval "$(zmx print-env)"
+  fi
+}
+PROMPT_COMMAND="_zmx_env_hook${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
+```
+
+### zsh
+
+Add to `~/.zshrc`:
+
+```zsh
+precmd() {
+  if [[ -n $ZMX_SESSION ]]; then
+    eval "$(zmx print-env)"
+  fi
+}
+```
+
+### fish
+
+Add to `~/.config/fish/config.fish`:
+
+```fish
+function _zmx_env_hook --on-event fish_prompt
+  if test -n "$ZMX_SESSION"
+    for pair in (zmx print-env | string split " ")
+      set -gx (string split -m 1 "=" $pair)
+    end
+  end
+end
+```
+
+### configuring tracked variables
+
+By default, `zmx` tracks:
+
+- `DISPLAY`
+- `SSH_AUTH_SOCK`
+- `SSH_AGENT_PID`
+- `SSH_CONNECTION`
+- `WINDOWID`
+- `XAUTHORITY`
+- `KITTY_LISTEN_ON`
+- `KITTY_PID`
+- `KITTY_WINDOW_ID`
+
+You can customize this list by setting `ZMX_TRACK_ENV` to a comma-separated list of variable names:
+
+```bash
+export ZMX_TRACK_ENV="DISPLAY,SSH_AUTH_SOCK,GPG_AGENT_INFO"
 ```
 
 ## shell completion

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Commands:
   [g]et <name>                             Get session labels
   set <name> k=v ...                       Set session labels
   [cl]ear <name>                           Clear all session labels
-  print-env [name] [key]                   Print tracked environment variables
+  print-env [-s] <name> [key]              Print tracked environment variables
   [k]ill <name>... [--force]               Kill session and all attached clients
   [hi]story <name> [--vt|--html]           Output session scrollback
   [w]ait <name>...                         Wait for session tasks to complete
@@ -218,8 +218,12 @@ A session's environment is initialized when the session is created. When re-atta
 `zmx` tracks these environment variables from attaching clients. You can inspect the current leader client's environment with `zmx print-env`:
 
 ```bash
-# Print all tracked environment variables as KEY=VALUE
-zmx print-env
+# Print all tracked environment variables (set variables as KEY=VALUE, unset as -KEY)
+zmx print-env .
+zmx print-env dev
+
+# Print POSIX shell commands (export ... / unset ...) suitable for eval
+zmx print-env -s .
 
 # Print a specific variable value
 zmx print-env . SSH_AUTH_SOCK
@@ -234,7 +238,7 @@ Add to `~/.bashrc`:
 ```bash
 _zmx_env_hook() {
   if [[ -n $ZMX_SESSION ]]; then
-    eval "$(zmx print-env)"
+    eval "$(zmx print-env -s .)"
   fi
 }
 PROMPT_COMMAND="_zmx_env_hook${PROMPT_COMMAND:+; $PROMPT_COMMAND}"
@@ -247,7 +251,7 @@ Add to `~/.zshrc`:
 ```zsh
 precmd() {
   if [[ -n $ZMX_SESSION ]]; then
-    eval "$(zmx print-env)"
+    eval "$(zmx print-env -s .)"
   fi
 }
 ```
@@ -259,7 +263,7 @@ Add to `~/.config/fish/config.fish`:
 ```fish
 function _zmx_env_hook --on-event fish_prompt
   if test -n "$ZMX_SESSION"
-    for pair in (zmx print-env | string split " ")
+    for pair in (zmx print-env . | string split " ")
       set -gx (string split -m 1 "=" $pair)
     end
   end

--- a/src/cfg.zig
+++ b/src/cfg.zig
@@ -12,6 +12,7 @@ log_dir: []const u8,
 max_scrollback_lines: usize = 2_000, // same default as tmux
 dir_mode: u32 = 0o750,
 log_mode: u32 = 0o640,
+tracked_envs: []const u8 = "DISPLAY,SSH_AUTH_SOCK,SSH_AGENT_PID,SSH_CONNECTION,WINDOWID,XAUTHORITY,KITTY_LISTEN_ON,KITTY_PID,KITTY_WINDOW_ID",
 
 pub fn init(alloc: std.mem.Allocator, io: std.Io) !Cfg {
     const socket_dir = try socketDir(alloc);
@@ -84,6 +85,23 @@ pub fn mkdir(self: *Cfg, io: std.Io) !void {
     try mkdirAll(io, self.log_dir, log_perms);
 }
 
+pub fn getTrackedEnvs(self: *Cfg, gpa: std.mem.Allocator) ![][]const u8 {
+    const env_keys = lib_posix.getenv("ZMX_TRACK_ENV") orelse self.tracked_envs;
+
+    var env_arr: std.ArrayList([]const u8) = .empty;
+    errdefer env_arr.deinit(gpa);
+
+    var iter = std.mem.splitScalar(u8, env_keys, ',');
+    while (iter.next()) |entry| {
+        const cur = std.mem.trim(u8, entry, " \t\r\n");
+        if (cur.len > 0) {
+            try env_arr.append(gpa, cur);
+        }
+    }
+
+    return try env_arr.toOwnedSlice(gpa);
+}
+
 fn mkdirAll(io: std.Io, sub_dir_path: []const u8, permissions: std.Io.Dir.Permissions) !void {
     var it = std.fs.path.componentIterator(sub_dir_path);
     var component = it.last() orelse return error.BadPathName;
@@ -130,4 +148,27 @@ test "Cfg.init uses custom modes from env vars" {
 
     try std.testing.expectEqual(@as(u32, 0o770), cfg.dir_mode);
     try std.testing.expectEqual(@as(u32, 0o660), cfg.log_mode);
+}
+
+test "Cfg.getTrackedEnvs defaults and custom" {
+    const alloc = std.testing.allocator;
+
+    _ = cross.c.unsetenv("ZMX_TRACK_ENV");
+    var cfg = try Cfg.init(alloc, std.testing.io);
+    defer cfg.deinit(alloc);
+
+    const default_envs = try cfg.getTrackedEnvs(alloc);
+    defer alloc.free(default_envs);
+    try std.testing.expectEqual(9, default_envs.len);
+    try std.testing.expectEqualStrings("DISPLAY", default_envs[0]);
+
+    _ = cross.c.setenv("ZMX_TRACK_ENV", "FOO, BAR,BAZ", 1);
+    defer _ = cross.c.unsetenv("ZMX_TRACK_ENV");
+
+    const custom_envs = try cfg.getTrackedEnvs(alloc);
+    defer alloc.free(custom_envs);
+    try std.testing.expectEqual(3, custom_envs.len);
+    try std.testing.expectEqualStrings("FOO", custom_envs[0]);
+    try std.testing.expectEqualStrings("BAR", custom_envs[1]);
+    try std.testing.expectEqualStrings("BAZ", custom_envs[2]);
 }

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -32,7 +32,7 @@ const bash_completions =
     \\  cur="${COMP_WORDS[COMP_CWORD]}"
     \\  prev="${COMP_WORDS[COMP_CWORD-1]}"
     \\
-    \\  local commands="attach run send print write detach list kill history get set clear wait tail completions version help"
+    \\  local commands="attach run send print write detach list kill history get set clear print-env wait tail completions version help"
     \\
     \\  if [[ $COMP_CWORD -eq 1 ]]; then
     \\    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
@@ -40,7 +40,7 @@ const bash_completions =
     \\  fi
     \\
     \\  case "$prev" in
-    \\    attach|run|send|print|write|kill|history|get|set|clear|wait|tail)
+    \\    attach|run|send|print|write|kill|history|get|set|clear|print-env|wait|tail)
     \\      local sessions=$(zmx list --short 2>/dev/null | tr '\n' ' ')
     \\      COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
     \\      ;;
@@ -89,6 +89,7 @@ const zsh_completions =
     \\        'get:Get session labels'
     \\        'set:Set session labels'
     \\        'clear:Clear all session labels'
+    \\        'print-env:Print tracked environment variables'
     \\        'version:Show version'
     \\        'help:Show help message'
     \\      )
@@ -96,7 +97,7 @@ const zsh_completions =
     \\      ;;
     \\    args)
     \\      case $words[2] in
-    \\        attach|a|kill|k|run|r|send|s|print|p|write|wr|history|get|g|set|clear|hi|wait|w|tail|t)
+    \\        attach|a|kill|k|run|r|send|s|print|p|write|wr|history|get|g|set|clear|print-env|hi|wait|w|tail|t)
     \\          _zmx_sessions
     \\          ;;
     \\        completions|c)
@@ -151,10 +152,11 @@ const fish_completions =
     \\complete -c zmx -n "__fish_is_nth_token 1" -a get -d 'Get session labels'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a set -d 'Set session labels'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a clear -d 'Clear all session labels'
+    \\complete -c zmx -n "__fish_is_nth_token 1" -a print-env -d 'Print tracked environment variables'
     \\complete -c zmx -n "__fish_is_nth_token 1" -a help -d 'Show help message'
     \\
     \\# Complete session names and shells
-    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run s send p print wr write hi history g get se set cl clear" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
+    \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from a attach r run s send p print wr write hi history g get se set cl clear print-env" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\complete -c zmx -n "not __fish_is_nth_token 1; and __fish_seen_subcommand_from k kill w wait t tail" -a '(zmx list --short 2>/dev/null)' -d 'Session name'
     \\
     \\complete -c zmx -n "__fish_is_nth_token 2; and __fish_seen_subcommand_from c completions" -a 'bash zsh fish nu' -d Shell
@@ -230,6 +232,11 @@ const nu_completions =
     \\
     \\export extern "zmx clear" [
     \\    name?: string@"nu-complete zmx sessions"
+    \\]
+    \\
+    \\export extern "zmx print-env" [
+    \\    name?: string@"nu-complete zmx sessions"
+    \\    key?: string
     \\]
     \\
     \\export extern "zmx help" []

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -170,6 +170,7 @@ const fish_completions =
     \\complete -c zmx -n "__fish_seen_subcommand_from k kill" -l force -d 'Force kill'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l vt -d 'History format for escape sequences'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l html -d 'History format for escape sequences'
+    \\complete -c zmx -n "__fish_seen_subcommand_from print-env" -s s -l shell -d 'Output POSIX export/unset commands for eval'
 ;
 
 const nu_completions =
@@ -235,8 +236,9 @@ const nu_completions =
     \\]
     \\
     \\export extern "zmx print-env" [
-    \\    name?: string@"nu-complete zmx sessions"
+    \\    name: string@"nu-complete zmx sessions"
     \\    key?: string
+    \\    --shell(-s)
     \\]
     \\
     \\export extern "zmx help" []

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -23,6 +23,9 @@ pub const Tag = enum(u8) {
     LabelClear = 16,
     LabelData = 17,
     Send = 18,
+    EnvGet = 19,
+    EnvSet = 20,
+    EnvData = 21,
     // Non-exhaustive: this enum comes off the wire via bytesToValue and
     // @enumFromInt, so out-of-range values are representable
     // rather than UB. Switches must handle `_` (unknown tag).

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -15,7 +15,7 @@ const builtin = @import("builtin");
 
 /// clientLoop sends ipc commands to its corresponding daemon.  It uses poll() as its non-blocking
 /// mechanism. It will send stdin to the daemon and receive stdout from the daemon.
-pub fn clientLoop(client_sock_fd: i32) !ClientResult {
+pub fn clientLoop(client_sock_fd: i32, env_str: []const u8) !ClientResult {
     std.log.info("client loop fd={d}", .{client_sock_fd});
     const gpa: std.mem.Allocator = blk: {
         if (builtin.mode == .Debug) {
@@ -40,6 +40,10 @@ pub fn clientLoop(client_sock_fd: i32) !ClientResult {
     // Buffer for outgoing socket writes
     var sock_write_buf = try std.ArrayList(u8).initCapacity(gpa, 4096);
     defer sock_write_buf.deinit(gpa);
+
+    if (env_str.len > 0) {
+        try ipc.appendMessage(gpa, &sock_write_buf, .EnvSet, env_str);
+    }
 
     // Send init message with terminal size (buffered)
     const size = ipc.getTerminalSize(lib_posix.STDOUT_FILENO);
@@ -473,9 +477,11 @@ fn daemonLoop(daemon: *Daemon, gpa: std.mem.Allocator, io: std.Io, server_sock_f
                         .LabelGet => try daemon.handleLabelGet(gpa, client),
                         .LabelSet => try daemon.handleLabelSet(gpa, client, msg.payload),
                         .LabelClear => try daemon.handleLabelClear(gpa, client),
+                        .EnvGet => try daemon.handleEnvGet(gpa, client),
+                        .EnvSet => try daemon.handleEnvSet(gpa, client, msg.payload),
                         .History => try daemon.handleHistory(gpa, client, &term, msg.payload),
                         .Run => try daemon.handleRun(gpa, io, client, msg.payload),
-                        .Ack, .TaskComplete, .LabelData => {},
+                        .Ack, .TaskComplete, .LabelData, .EnvData => {},
                         .Write => try daemon.handleWrite(gpa, client, msg.payload),
                         _ => std.log.warn(
                             "ignoring unknown IPC tag={d}",
@@ -530,11 +536,43 @@ pub const Client = struct {
     has_pending_output: bool = false,
     read_buf: ipc.SocketBuffer,
     write_buf: std.ArrayList(u8),
+    env_map: std.StringHashMapUnmanaged([]u8) = .empty,
 
-    pub fn deinit(self: *Client) void {
+    pub fn deinit(self: *Client, gpa: std.mem.Allocator) void {
         lib_posix.close(self.socket_fd);
         self.read_buf.deinit();
         self.write_buf.deinit(self.alloc);
+        var it = self.env_map.iterator();
+        while (it.next()) |entry| {
+            gpa.free(entry.key_ptr.*);
+            gpa.free(entry.value_ptr.*);
+        }
+        self.env_map.deinit(gpa);
+    }
+
+    fn setEnv(self: *Client, gpa: std.mem.Allocator, env_str: []const u8) !void {
+        var kvs = label.LabelIterator.init(env_str);
+        while (kvs.next()) |kv| {
+            if (kv.value.len == 0) {
+                if (self.env_map.fetchRemove(kv.key)) |existing| {
+                    gpa.free(existing.key);
+                    gpa.free(existing.value);
+                }
+                continue;
+            }
+
+            const owned_key = try gpa.dupe(u8, kv.key);
+            errdefer gpa.free(owned_key);
+            const owned_value = try gpa.dupe(u8, kv.value);
+            errdefer gpa.free(owned_value);
+            if (try self.env_map.fetchPut(gpa, owned_key, owned_value)) |existing| {
+                // fetchPut does NOT replace the key in the map, the old
+                // key pointer stays. So free the new (unused) key and the
+                // old value.
+                gpa.free(owned_key);
+                gpa.free(existing.value);
+            }
+        }
     }
 };
 
@@ -611,7 +649,7 @@ pub const Daemon = struct {
         self.running = false;
 
         for (self.clients.items) |client| {
-            client.deinit();
+            client.deinit(gpa);
             gpa.destroy(client);
         }
         self.clients.clearRetainingCapacity();
@@ -627,7 +665,7 @@ pub const Daemon = struct {
             );
             self.leader_client_fd = null;
         }
-        client.deinit();
+        client.deinit(gpa);
         gpa.destroy(client);
         _ = self.clients.orderedRemove(i);
         std.log.info("client disconnected fd={d} remaining={d}", .{ fd, self.clients.items.len });
@@ -810,6 +848,15 @@ pub const Daemon = struct {
         // so we can resize the pty and ghostty state.
         try ipc.appendMessage(gpa, &client.write_buf, .Resize, "");
         client.has_pending_output = true;
+    }
+
+    fn getLeaderClient(self: *Daemon) ?*Client {
+        for (self.clients.items) |client| {
+            if (self.leader_client_fd == client.socket_fd) {
+                return client;
+            }
+        }
+        return null;
     }
 
     const PTY_WRITE_BUF_MAX = 256 * 1024;
@@ -1013,7 +1060,7 @@ pub const Daemon = struct {
     pub fn handleDetachAll(self: *Daemon, gpa: std.mem.Allocator) void {
         std.log.info("detach all clients={d}", .{self.clients.items.len});
         for (self.clients.items) |client_to_close| {
-            client_to_close.deinit();
+            client_to_close.deinit(gpa);
             gpa.destroy(client_to_close);
         }
         self.clients.clearRetainingCapacity();
@@ -1255,6 +1302,26 @@ pub const Daemon = struct {
         );
     }
 
+    fn handleEnvGet(self: *Daemon, gpa: std.mem.Allocator, client: *Client) !void {
+        const leader_opt = self.getLeaderClient();
+        if (leader_opt) |leader| {
+            const out = try label.labelsToU8(gpa, leader.env_map);
+            defer gpa.free(out);
+            try ipc.appendMessage(gpa, &client.write_buf, .EnvData, out);
+        } else {
+            try ipc.appendMessage(gpa, &client.write_buf, .EnvData, "");
+        }
+        client.has_pending_output = true;
+    }
+
+    fn handleEnvSet(_: *Daemon, gpa: std.mem.Allocator, client: *Client, env_str: []const u8) !void {
+        std.log.info("handle env set payload={s}", .{env_str});
+        try client.setEnv(gpa, env_str);
+
+        try ipc.appendMessage(gpa, &client.write_buf, .Ack, "");
+        client.has_pending_output = true;
+    }
+
     fn handleLabelGet(self: *Daemon, gpa: std.mem.Allocator, client: *Client) !void {
         const out = try label.labelsToU8(gpa, self.labels);
         defer gpa.free(out);
@@ -1322,4 +1389,86 @@ test "send queues PTY input without changing leader" {
 
     try std.testing.expectEqual(@as(?i32, 42), daemon.leader_client_fd);
     try std.testing.expectEqualStrings("hello", daemon.pty_write_buf.items);
+}
+
+test "handleEnvGet returns leader client's environment variables" {
+    const alloc = std.testing.allocator;
+    var cfg = Cfg{
+        .socket_dir = "/tmp",
+        .log_dir = "/tmp",
+    };
+
+    var daemon = Daemon{
+        .cfg = &cfg,
+        .clients = .empty,
+        .session_name = "test",
+        .socket_path = try alloc.dupe(u8, ""),
+        .running = true,
+        .pid = 0,
+        .created_at = 0,
+    };
+    defer daemon.deinit(alloc);
+
+    const fds1 = try lib_posix.pipe2(.{});
+    defer lib_posix.close(fds1[1]);
+    var client1 = Client{
+        .alloc = alloc,
+        .socket_fd = fds1[0],
+        .read_buf = try ipc.SocketBuffer.init(alloc),
+        .write_buf = std.ArrayList(u8).empty,
+    };
+    defer client1.deinit(alloc);
+    try client1.setEnv(alloc, "DISPLAY=:1 SSH_AUTH_SOCK=/tmp/ssh-1 KITTY_LISTEN_ON=unix:/tmp/kitty-1");
+
+    const fds2 = try lib_posix.pipe2(.{});
+    defer lib_posix.close(fds2[1]);
+    var client2 = Client{
+        .alloc = alloc,
+        .socket_fd = fds2[0],
+        .read_buf = try ipc.SocketBuffer.init(alloc),
+        .write_buf = std.ArrayList(u8).empty,
+    };
+    defer client2.deinit(alloc);
+    try client2.setEnv(alloc, "SSH_AUTH_SOCK=/tmp/ssh-2 WINDOWID=12345 KITTY_LISTEN_ON=unix:/tmp/kitty-2");
+
+    const fds_req = try lib_posix.pipe2(.{});
+    defer lib_posix.close(fds_req[1]);
+    var client_req = Client{
+        .alloc = alloc,
+        .socket_fd = fds_req[0],
+        .read_buf = try ipc.SocketBuffer.init(alloc),
+        .write_buf = std.ArrayList(u8).empty,
+    };
+    defer client_req.deinit(alloc);
+
+    try daemon.clients.append(alloc, &client1);
+    try daemon.clients.append(alloc, &client2);
+
+    // No leader yet -> handleEnvGet returns empty string payload
+    try daemon.handleEnvGet(alloc, &client_req);
+    try std.testing.expect(client_req.write_buf.items.len > 0);
+    client_req.write_buf.clearRetainingCapacity();
+
+    // Set client1 as leader
+    try daemon.setLeader(alloc, &client1);
+    try std.testing.expectEqual(@as(?i32, fds1[0]), daemon.leader_client_fd);
+    try daemon.handleEnvGet(alloc, &client_req);
+    // Wire message: [Header][Payload]
+    const pay1 = client_req.write_buf.items[@sizeOf(ipc.Header)..];
+    try std.testing.expectEqualStrings("DISPLAY=:1 KITTY_LISTEN_ON=unix:/tmp/kitty-1 SSH_AUTH_SOCK=/tmp/ssh-1", pay1);
+    client_req.write_buf.clearRetainingCapacity();
+
+    // Switch leader to client2
+    try daemon.setLeader(alloc, &client2);
+    try std.testing.expectEqual(@as(?i32, fds2[0]), daemon.leader_client_fd);
+    try daemon.handleEnvGet(alloc, &client_req);
+    const pay2 = client_req.write_buf.items[@sizeOf(ipc.Header)..];
+    try std.testing.expectEqualStrings("KITTY_LISTEN_ON=unix:/tmp/kitty-2 SSH_AUTH_SOCK=/tmp/ssh-2 WINDOWID=12345", pay2);
+    client_req.write_buf.clearRetainingCapacity();
+
+    // Client2 updates env
+    try daemon.handleEnvSet(alloc, &client2, "DISPLAY=:99");
+    try daemon.handleEnvGet(alloc, &client_req);
+    const pay3 = client_req.write_buf.items[@sizeOf(ipc.Header)..];
+    try std.testing.expectEqualStrings("DISPLAY=:99 KITTY_LISTEN_ON=unix:/tmp/kitty-2 SSH_AUTH_SOCK=/tmp/ssh-2 WINDOWID=12345", pay3);
 }

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -536,7 +536,7 @@ pub const Client = struct {
     has_pending_output: bool = false,
     read_buf: ipc.SocketBuffer,
     write_buf: std.ArrayList(u8),
-    env_map: std.StringHashMapUnmanaged([]u8) = .empty,
+    env_map: std.StringHashMapUnmanaged(?[]u8) = .empty,
 
     pub fn deinit(self: *Client, gpa: std.mem.Allocator) void {
         lib_posix.close(self.socket_fd);
@@ -545,32 +545,38 @@ pub const Client = struct {
         var it = self.env_map.iterator();
         while (it.next()) |entry| {
             gpa.free(entry.key_ptr.*);
-            gpa.free(entry.value_ptr.*);
+            if (entry.value_ptr.*) |val| {
+                gpa.free(val);
+            }
         }
         self.env_map.deinit(gpa);
     }
 
     fn setEnv(self: *Client, gpa: std.mem.Allocator, env_str: []const u8) !void {
-        var kvs = label.LabelIterator.init(env_str);
-        while (kvs.next()) |kv| {
-            if (kv.value.len == 0) {
-                if (self.env_map.fetchRemove(kv.key)) |existing| {
-                    gpa.free(existing.key);
-                    gpa.free(existing.value);
+        var it = std.mem.splitScalar(u8, env_str, '\n');
+        while (it.next()) |line| {
+            if (line.len == 0) continue;
+            if (line[0] == '-') {
+                const key = line[1..];
+                if (key.len == 0) continue;
+                const owned_key = try gpa.dupe(u8, key);
+                errdefer gpa.free(owned_key);
+                if (try self.env_map.fetchPut(gpa, owned_key, null)) |existing| {
+                    gpa.free(owned_key);
+                    if (existing.value) |v| gpa.free(v);
                 }
-                continue;
-            }
-
-            const owned_key = try gpa.dupe(u8, kv.key);
-            errdefer gpa.free(owned_key);
-            const owned_value = try gpa.dupe(u8, kv.value);
-            errdefer gpa.free(owned_value);
-            if (try self.env_map.fetchPut(gpa, owned_key, owned_value)) |existing| {
-                // fetchPut does NOT replace the key in the map, the old
-                // key pointer stays. So free the new (unused) key and the
-                // old value.
-                gpa.free(owned_key);
-                gpa.free(existing.value);
+            } else if (std.mem.indexOfScalar(u8, line, '=')) |eq_idx| {
+                const key = line[0..eq_idx];
+                const val = line[eq_idx + 1 ..];
+                if (key.len == 0) continue;
+                const owned_key = try gpa.dupe(u8, key);
+                errdefer gpa.free(owned_key);
+                const owned_value = try gpa.dupe(u8, val);
+                errdefer gpa.free(owned_value);
+                if (try self.env_map.fetchPut(gpa, owned_key, owned_value)) |existing| {
+                    gpa.free(owned_key);
+                    if (existing.value) |v| gpa.free(v);
+                }
             }
         }
     }
@@ -1305,9 +1311,36 @@ pub const Daemon = struct {
     fn handleEnvGet(self: *Daemon, gpa: std.mem.Allocator, client: *Client) !void {
         const leader_opt = self.getLeaderClient();
         if (leader_opt) |leader| {
-            const out = try label.labelsToU8(gpa, leader.env_map);
-            defer gpa.free(out);
-            try ipc.appendMessage(gpa, &client.write_buf, .EnvData, out);
+            var keys = std.ArrayList([]const u8).empty;
+            defer keys.deinit(gpa);
+            var it = leader.env_map.iterator();
+            while (it.next()) |entry| {
+                try keys.append(gpa, entry.key_ptr.*);
+            }
+            std.mem.sort([]const u8, keys.items, {}, struct {
+                fn lessThan(_: void, a: []const u8, b: []const u8) bool {
+                    return std.mem.order(u8, a, b) == .lt;
+                }
+            }.lessThan);
+
+            var out = std.ArrayList(u8).empty;
+            defer out.deinit(gpa);
+
+            for (keys.items) |key| {
+                if (leader.env_map.get(key)) |val_opt| {
+                    if (val_opt) |val| {
+                        try out.appendSlice(gpa, key);
+                        try out.append(gpa, '=');
+                        try out.appendSlice(gpa, val);
+                        try out.append(gpa, '\n');
+                    } else {
+                        try out.append(gpa, '-');
+                        try out.appendSlice(gpa, key);
+                        try out.append(gpa, '\n');
+                    }
+                }
+            }
+            try ipc.appendMessage(gpa, &client.write_buf, .EnvData, out.items);
         } else {
             try ipc.appendMessage(gpa, &client.write_buf, .EnvData, "");
         }
@@ -1391,7 +1424,7 @@ test "send queues PTY input without changing leader" {
     try std.testing.expectEqualStrings("hello", daemon.pty_write_buf.items);
 }
 
-test "handleEnvGet returns leader client's environment variables" {
+test "handleEnvGet returns leader client's environment variables including unsets" {
     const alloc = std.testing.allocator;
     var cfg = Cfg{
         .socket_dir = "/tmp",
@@ -1418,7 +1451,7 @@ test "handleEnvGet returns leader client's environment variables" {
         .write_buf = std.ArrayList(u8).empty,
     };
     defer client1.deinit(alloc);
-    try client1.setEnv(alloc, "DISPLAY=:1 SSH_AUTH_SOCK=/tmp/ssh-1 KITTY_LISTEN_ON=unix:/tmp/kitty-1");
+    try client1.setEnv(alloc, "DISPLAY=:1\nSSH_AUTH_SOCK=/tmp/ssh-1\nKITTY_LISTEN_ON=unix:/tmp/kitty-1\n-WINDOWID\n");
 
     const fds2 = try lib_posix.pipe2(.{});
     defer lib_posix.close(fds2[1]);
@@ -1429,7 +1462,7 @@ test "handleEnvGet returns leader client's environment variables" {
         .write_buf = std.ArrayList(u8).empty,
     };
     defer client2.deinit(alloc);
-    try client2.setEnv(alloc, "SSH_AUTH_SOCK=/tmp/ssh-2 WINDOWID=12345 KITTY_LISTEN_ON=unix:/tmp/kitty-2");
+    try client2.setEnv(alloc, "SSH_AUTH_SOCK=/tmp/ssh-2\nWINDOWID=12345\nKITTY_LISTEN_ON=unix:/tmp/kitty-2\n-DISPLAY\n");
 
     const fds_req = try lib_posix.pipe2(.{});
     defer lib_posix.close(fds_req[1]);
@@ -1455,7 +1488,7 @@ test "handleEnvGet returns leader client's environment variables" {
     try daemon.handleEnvGet(alloc, &client_req);
     // Wire message: [Header][Payload]
     const pay1 = client_req.write_buf.items[@sizeOf(ipc.Header)..];
-    try std.testing.expectEqualStrings("DISPLAY=:1 KITTY_LISTEN_ON=unix:/tmp/kitty-1 SSH_AUTH_SOCK=/tmp/ssh-1", pay1);
+    try std.testing.expectEqualStrings("DISPLAY=:1\nKITTY_LISTEN_ON=unix:/tmp/kitty-1\nSSH_AUTH_SOCK=/tmp/ssh-1\n-WINDOWID\n", pay1);
     client_req.write_buf.clearRetainingCapacity();
 
     // Switch leader to client2
@@ -1463,12 +1496,12 @@ test "handleEnvGet returns leader client's environment variables" {
     try std.testing.expectEqual(@as(?i32, fds2[0]), daemon.leader_client_fd);
     try daemon.handleEnvGet(alloc, &client_req);
     const pay2 = client_req.write_buf.items[@sizeOf(ipc.Header)..];
-    try std.testing.expectEqualStrings("KITTY_LISTEN_ON=unix:/tmp/kitty-2 SSH_AUTH_SOCK=/tmp/ssh-2 WINDOWID=12345", pay2);
+    try std.testing.expectEqualStrings("-DISPLAY\nKITTY_LISTEN_ON=unix:/tmp/kitty-2\nSSH_AUTH_SOCK=/tmp/ssh-2\nWINDOWID=12345\n", pay2);
     client_req.write_buf.clearRetainingCapacity();
 
     // Client2 updates env
-    try daemon.handleEnvSet(alloc, &client2, "DISPLAY=:99");
+    try daemon.handleEnvSet(alloc, &client2, "DISPLAY=:99\n");
     try daemon.handleEnvGet(alloc, &client_req);
     const pay3 = client_req.write_buf.items[@sizeOf(ipc.Header)..];
-    try std.testing.expectEqualStrings("DISPLAY=:99 KITTY_LISTEN_ON=unix:/tmp/kitty-2 SSH_AUTH_SOCK=/tmp/ssh-2 WINDOWID=12345", pay3);
+    try std.testing.expectEqualStrings("DISPLAY=:99\nKITTY_LISTEN_ON=unix:/tmp/kitty-2\nSSH_AUTH_SOCK=/tmp/ssh-2\nWINDOWID=12345\n", pay3);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const Environ = std.process.Environ;
 const build_options = @import("build_options");
 const ghostty_vt = @import("ghostty-vt");
 const ipc = @import("ipc.zig");
@@ -160,7 +161,14 @@ pub fn main(init: std.process.Init) !void {
         daemon.setCwd(cwd);
         daemon.shell = shell_env;
         std.log.info("socket path={s}", .{daemon.socket_path});
-        return attach(gpa, io, &daemon, parsed.labels);
+
+        var env_buf: [4096]u8 = undefined;
+        const tracked_envs = try cfg.getTrackedEnvs(gpa);
+        defer gpa.free(tracked_envs);
+
+        const env_str = try getTrackedEnvStr(&env_buf, tracked_envs, init.environ_map);
+
+        return attach(gpa, io, &daemon, env_str, parsed.labels);
     } else if (std.mem.eql(u8, cmd, "run") or std.mem.eql(u8, cmd, "r")) {
         const session_name = args.next() orelse "";
         if (std.mem.eql(u8, session_name, "--help") or std.mem.eql(u8, session_name, "-h")) {
@@ -409,6 +417,15 @@ pub fn main(init: std.process.Init) !void {
         daemon.shell = shell_env;
         std.log.info("socket path={s}", .{daemon.socket_path});
         try writeFile(gpa, io, &daemon, file_path);
+    } else if (std.mem.eql(u8, cmd, "print-env")) {
+        const sesh_name = args.next();
+        if (sesh_name) |name| {
+            if (detectHelp(name)) return help(io);
+        }
+        const sesh = try socket.resolveSessionOrEnv(gpa, io, sesh_name);
+        defer gpa.free(sesh);
+        const single_kv = args.next() orelse "";
+        return envGet(gpa, io, &cfg, sesh, single_kv);
     } else {
         return help(io);
     }
@@ -422,22 +439,23 @@ fn help(io: std.Io) !void {
         \\
         \\Commands:
         \\  [a]ttach [--labels kv] <name> [command...]  Attach to session, creating if needed
-        \\  [r]un <name> [-d] [command...]           Send command without attaching
-        \\  [s]end <name> <text...>                  Send raw input to session PTY
-        \\  [p]rint <name> <text...>                 Inject text into session display
-        \\  [wr]ite <name> <file_path>               Write stdin to file_path through the session
-        \\  [d]etach                                 Detach all clients (ctrl+\\ for current client)
-        \\  [l]ist|ls [--short|--where k=v]          List active sessions
-        \\  [g]et <name>                             Get session labels
-        \\  set <name> k=v ...                     Set session labels (k= to remove)
-        \\  [cl]ear <name>                           Clear all session labels
-        \\  [k]ill <name>... [--force]               Kill session and all attached clients
-        \\  [hi]story <name> [--vt|--html]           Output session scrollback
-        \\  [w]ait <name>...                         Wait for session tasks to complete
-        \\  [t]ail <name>...                         Follow session output
-        \\  [c]ompletions <shell>                    Shell completions (bash, zsh, fish, nu)
-        \\  [v]ersion                                Show version and metadata (socket dir, log dir)
-        \\  [h]elp                                   Show this help
+        \\  [r]un <name> [-d] [command...]              Send command without attaching
+        \\  [s]end <name> <text...>                     Send raw input to session PTY
+        \\  [p]rint <name> <text...>                    Inject text into session display
+        \\  [wr]ite <name> <file_path>                  Write stdin to file_path through the session
+        \\  [d]etach                                    Detach all clients (ctrl+\\ for current client)
+        \\  [l]ist|ls [--short|--where k=v]             List active sessions
+        \\  [g]et <name>                                Get session labels
+        \\  set <name> k=v ...                          Set session labels (k= to remove)
+        \\  [cl]ear <name>                              Clear all session labels
+        \\  print-env [name] [key]                      Print tracked environment variables
+        \\  [k]ill <name>... [--force]                  Kill session and all attached clients
+        \\  [hi]story <name> [--vt|--html]              Output session scrollback
+        \\  [w]ait <name>...                            Wait for session tasks to complete
+        \\  [t]ail <name>...                            Follow session output
+        \\  [c]ompletions <shell>                       Shell completions (bash, zsh, fish, nu)
+        \\  [v]ersion                                   Show version and metadata (socket dir, log dir)
+        \\  [h]elp                                      Show this help
         \\
         \\Attach:
         \\  This will spawn a login $SHELL with a PTY.  You can provide a
@@ -545,6 +563,15 @@ fn help(io: std.Io) !void {
         \\    zmx list | grep project=zmx
         \\    zmx clear dev
         \\
+        \\Print-env:
+        \\  Print tracked environment variables for the leader client of a session.
+        \\
+        \\  Examples:
+        \\    zmx print-env .
+        \\    zmx print-env dev
+        \\    zmx print-env dev DISPLAY
+        \\    eval "$(zmx print-env)"    # inside shell session precmd hook
+        \\
         \\Environment variables:
         \\  SHELL                Default shell for new sessions
         \\  ZMX_DIR              Socket directory (priority 1)
@@ -553,6 +580,8 @@ fn help(io: std.Io) !void {
         \\  ZMX_SESSION          Session name (injected automatically; makes attach
         \\                       switch this session)
         \\  ZMX_SESSION_PREFIX   Prefix added to all session names
+        \\  ZMX_TRACK_ENV        Comma-separated list of environment variables to track
+        \\                       from attaching clients
         \\  ZMX_DIR_MODE         Sets mode for socket and log directories (octal, defaults to 0750)
         \\  ZMX_LOG_MODE         Sets mode for log files (octal, defaults to 0640)
         \\  ZMX_NO_DETACH_KEY    Disables the ctrl+\ detach shortcut (set to any value)
@@ -1122,6 +1151,65 @@ fn assertLabels(io: std.Io, labels: []const u8) void {
     }
 }
 
+fn getTrackedEnvStr(
+    buf: []u8,
+    tracked_envs: []const []const u8,
+    env_map: *const std.process.Environ.Map,
+) ![]const u8 {
+    var offset: usize = 0;
+
+    for (tracked_envs) |env| {
+        if (env_map.get(env)) |val| {
+            const prefix = if (offset > 0) " " else "";
+            const segment = try std.fmt.bufPrint(buf[offset..], "{s}{s}={s}", .{ prefix, env, val });
+            offset += segment.len;
+        }
+    }
+
+    return buf[0..offset];
+}
+
+fn envSet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, env_str: []const u8) !void {
+    std.log.info("env set session={s}", .{session_name});
+
+    const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
+        error.NameTooLong => return socket.printSessionNameTooLong(io, session_name, cfg.socket_dir),
+        error.OutOfMemory => return err,
+    };
+    defer alloc.free(socket_path);
+
+    _ = ipc.roundTripForTag(alloc, socket_path, .EnvSet, env_str, .Ack) catch |err| {
+        printLabelError(io, session_name, err);
+    };
+}
+
+fn envGet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, single_kv: []const u8) !void {
+    std.log.info("env get session={s}", .{session_name});
+
+    const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
+        error.NameTooLong => return socket.printSessionNameTooLong(io, session_name, cfg.socket_dir),
+        error.OutOfMemory => return err,
+    };
+    defer alloc.free(socket_path);
+
+    const payload = ipc.roundTripForTag(alloc, socket_path, .EnvGet, "", .EnvData) catch |err| {
+        printLabelError(io, session_name, err);
+    };
+    defer alloc.free(payload);
+
+    var buf: [4096]u8 = undefined;
+    var stdout = std.Io.File.stdout().writer(io, &buf);
+    if (single_kv.len == 0) {
+        try stdout.interface.print("{s}", .{payload});
+        try stdout.interface.flush();
+        return;
+    }
+
+    const val = try label.getLabelValueFromPairs(single_kv, payload);
+    try stdout.interface.print("{s}", .{val});
+    try stdout.interface.flush();
+}
+
 fn labelSet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, labels: []const u8) !void {
     std.log.info("label set session={s}", .{session_name});
 
@@ -1358,7 +1446,7 @@ fn parseAttachArgs(argv: []const []const u8) AttachArgs {
     return parsed;
 }
 
-fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, labels: ?[]const u8) !void {
+fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, env_str: []const u8, labels: ?[]const u8) !void {
     const sesh = socket.getSeshNameFromEnv();
     if (sesh.len > 0) {
         return switchSesh(gpa, io, daemon, sesh);
@@ -1425,7 +1513,7 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, labels: ?[]const 
     const clear_seq = "\x1b[2J\x1b[H";
     _ = try lib_posix.write(lib_posix.STDOUT_FILENO, clear_seq);
 
-    const looper = try loop.clientLoop(client_sock);
+    const looper = try loop.clientLoop(client_sock, env_str);
     switch (looper.kind) {
         .detach => return,
         .switch_session => {
@@ -1453,7 +1541,7 @@ fn attach(gpa: std.mem.Allocator, io: std.Io, daemon: *Daemon, labels: ?[]const 
                 std.log.info("switching to new session cwd={s}", .{switch_cwd});
                 target_daemon.setCwd(switch_cwd);
                 target_daemon.shell = daemon.shell;
-                return attach(gpa, io, &target_daemon, null);
+                return attach(gpa, io, &target_daemon, env_str, null);
             }
         },
     }

--- a/src/main.zig
+++ b/src/main.zig
@@ -162,11 +162,11 @@ pub fn main(init: std.process.Init) !void {
         daemon.shell = shell_env;
         std.log.info("socket path={s}", .{daemon.socket_path});
 
-        var env_buf: [4096]u8 = undefined;
         const tracked_envs = try cfg.getTrackedEnvs(gpa);
         defer gpa.free(tracked_envs);
 
-        const env_str = try getTrackedEnvStr(&env_buf, tracked_envs, init.environ_map);
+        const env_str = try getTrackedEnvStr(gpa, tracked_envs, init.environ_map);
+        defer gpa.free(env_str);
 
         return attach(gpa, io, &daemon, env_str, parsed.labels);
     } else if (std.mem.eql(u8, cmd, "run") or std.mem.eql(u8, cmd, "r")) {
@@ -418,14 +418,25 @@ pub fn main(init: std.process.Init) !void {
         std.log.info("socket path={s}", .{daemon.socket_path});
         try writeFile(gpa, io, &daemon, file_path);
     } else if (std.mem.eql(u8, cmd, "print-env")) {
-        const sesh_name = args.next();
-        if (sesh_name) |name| {
-            if (detectHelp(name)) return help(io);
+        var shell_mode = false;
+        var session_name: ?[]const u8 = null;
+        var single_kv: []const u8 = "";
+
+        while (args.next()) |arg| {
+            if (detectHelp(arg)) return help(io);
+            if (std.mem.eql(u8, arg, "-s") or std.mem.eql(u8, arg, "--shell")) {
+                shell_mode = true;
+            } else if (session_name == null) {
+                session_name = arg;
+            } else if (single_kv.len == 0) {
+                single_kv = arg;
+            }
         }
-        const sesh = try socket.resolveSessionOrEnv(gpa, io, sesh_name);
+
+        const sesh_arg = session_name orelse return error.SessionNameRequired;
+        const sesh = try socket.resolveSessionOrEnv(gpa, io, sesh_arg);
         defer gpa.free(sesh);
-        const single_kv = args.next() orelse "";
-        return envGet(gpa, io, &cfg, sesh, single_kv);
+        return envGet(gpa, io, &cfg, sesh, single_kv, shell_mode);
     } else {
         return help(io);
     }
@@ -448,7 +459,7 @@ fn help(io: std.Io) !void {
         \\  [g]et <name>                                Get session labels
         \\  set <name> k=v ...                          Set session labels (k= to remove)
         \\  [cl]ear <name>                              Clear all session labels
-        \\  print-env [name] [key]                      Print tracked environment variables
+        \\  print-env [-s] <name> [key]                 Print tracked environment variables
         \\  [k]ill <name>... [--force]                  Kill session and all attached clients
         \\  [hi]story <name> [--vt|--html]              Output session scrollback
         \\  [w]ait <name>...                            Wait for session tasks to complete
@@ -566,11 +577,15 @@ fn help(io: std.Io) !void {
         \\Print-env:
         \\  Print tracked environment variables for the leader client of a session.
         \\
+        \\  Flags:
+        \\    -s, --shell       Output POSIX export/unset commands for eval
+        \\
         \\  Examples:
         \\    zmx print-env .
+        \\    zmx print-env -s .
         \\    zmx print-env dev
         \\    zmx print-env dev DISPLAY
-        \\    eval "$(zmx print-env)"    # inside shell session precmd hook
+        \\    eval "$(zmx print-env -s .)"    # inside shell session precmd hook
         \\
         \\Environment variables:
         \\  SHELL                Default shell for new sessions
@@ -1152,21 +1167,60 @@ fn assertLabels(io: std.Io, labels: []const u8) void {
 }
 
 fn getTrackedEnvStr(
-    buf: []u8,
+    alloc: std.mem.Allocator,
     tracked_envs: []const []const u8,
     env_map: *const std.process.Environ.Map,
-) ![]const u8 {
-    var offset: usize = 0;
+) ![]u8 {
+    var out = std.ArrayList(u8).empty;
+    errdefer out.deinit(alloc);
 
     for (tracked_envs) |env| {
         if (env_map.get(env)) |val| {
-            const prefix = if (offset > 0) " " else "";
-            const segment = try std.fmt.bufPrint(buf[offset..], "{s}{s}={s}", .{ prefix, env, val });
-            offset += segment.len;
+            try out.appendSlice(alloc, env);
+            try out.append(alloc, '=');
+            try out.appendSlice(alloc, val);
+            try out.append(alloc, '\n');
+        } else {
+            try out.append(alloc, '-');
+            try out.appendSlice(alloc, env);
+            try out.append(alloc, '\n');
         }
     }
 
-    return buf[0..offset];
+    return out.toOwnedSlice(alloc);
+}
+
+fn getEnvValue(key: []const u8, payload: []const u8) error{EnvVarNotFound}![]const u8 {
+    var it = std.mem.splitScalar(u8, payload, '\n');
+    while (it.next()) |line| {
+        if (line.len == 0) continue;
+        if (line[0] == '-') {
+            if (std.mem.eql(u8, line[1..], key)) {
+                return error.EnvVarNotFound;
+            }
+        } else if (std.mem.indexOfScalar(u8, line, '=')) |eq_idx| {
+            if (std.mem.eql(u8, line[0..eq_idx], key)) {
+                return line[eq_idx + 1 ..];
+            }
+        }
+    }
+    return error.EnvVarNotFound;
+}
+
+fn printEnvError(io: std.Io, session_name: []const u8, err: anyerror) noreturn {
+    var buf: [4096]u8 = undefined;
+    var w = std.Io.File.stderr().writer(io, &buf);
+    switch (err) {
+        error.SessionNotFound => w.interface.print("error: session \"{s}\" not found\n", .{session_name}) catch {},
+        error.DaemonUnresponsive => w.interface.print("error: session \"{s}\" daemon unresponsive\n", .{session_name}) catch {},
+        error.EnvVarNotFound => w.interface.print("error: environment variable not found\n", .{}) catch {},
+        else => w.interface.print(
+            "error: could not communicate with session \"{s}\" err={s}\n",
+            .{ session_name, @errorName(err) },
+        ) catch {},
+    }
+    w.interface.flush() catch {};
+    std.process.exit(1);
 }
 
 fn envSet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, env_str: []const u8) !void {
@@ -1179,11 +1233,11 @@ fn envSet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const
     defer alloc.free(socket_path);
 
     _ = ipc.roundTripForTag(alloc, socket_path, .EnvSet, env_str, .Ack) catch |err| {
-        printLabelError(io, session_name, err);
+        printEnvError(io, session_name, err);
     };
 }
 
-fn envGet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, single_kv: []const u8) !void {
+fn envGet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, single_kv: []const u8, shell_mode: bool) !void {
     std.log.info("env get session={s}", .{session_name});
 
     const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
@@ -1193,20 +1247,47 @@ fn envGet(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const
     defer alloc.free(socket_path);
 
     const payload = ipc.roundTripForTag(alloc, socket_path, .EnvGet, "", .EnvData) catch |err| {
-        printLabelError(io, session_name, err);
+        printEnvError(io, session_name, err);
     };
     defer alloc.free(payload);
 
     var buf: [4096]u8 = undefined;
     var stdout = std.Io.File.stdout().writer(io, &buf);
-    if (single_kv.len == 0) {
-        try stdout.interface.print("{s}", .{payload});
+    if (single_kv.len > 0) {
+        const val = getEnvValue(single_kv, payload) catch |err| {
+            printEnvError(io, session_name, err);
+        };
+        try stdout.interface.print("{s}\n", .{val});
         try stdout.interface.flush();
         return;
     }
 
-    const val = try label.getLabelValueFromPairs(single_kv, payload);
-    try stdout.interface.print("{s}", .{val});
+    if (payload.len == 0) return;
+
+    if (shell_mode) {
+        var it = std.mem.splitScalar(u8, payload, '\n');
+        while (it.next()) |line| {
+            if (line.len == 0) continue;
+            if (line[0] == '-') {
+                const key = line[1..];
+                try stdout.interface.print("unset {s};\n", .{key});
+            } else if (std.mem.indexOfScalar(u8, line, '=')) |eq_idx| {
+                const key = line[0..eq_idx];
+                const val = line[eq_idx + 1 ..];
+                try stdout.interface.print("export {s}='", .{key});
+                for (val) |c| {
+                    if (c == '\'') {
+                        try stdout.interface.print("'\\''", .{});
+                    } else {
+                        try stdout.interface.print("{c}", .{c});
+                    }
+                }
+                try stdout.interface.print("';\n", .{});
+            }
+        }
+    } else {
+        try stdout.interface.print("{s}", .{payload});
+    }
     try stdout.interface.flush();
 }
 
@@ -1838,4 +1919,28 @@ test "parseAttachArgs leaves labels unset when the flag is absent" {
     const parsed = parseAttachArgs(&.{"dev"});
     try std.testing.expectEqual(@as(?[]const u8, null), parsed.labels);
     try std.testing.expect(!parsed.missing_labels_value);
+}
+
+test "getTrackedEnvStr includes set and unset entries" {
+    const alloc = std.testing.allocator;
+    var env_map = std.process.Environ.Map.init(alloc);
+    defer env_map.deinit();
+
+    try env_map.put("DISPLAY", ":1");
+    try env_map.put("SSH_AUTH_SOCK", "/tmp/ssh.sock");
+
+    const tracked = [_][]const u8{ "DISPLAY", "KITTY_WINDOW_ID", "SSH_AUTH_SOCK" };
+    const str = try getTrackedEnvStr(alloc, &tracked, &env_map);
+    defer alloc.free(str);
+
+    try std.testing.expectEqualStrings("DISPLAY=:1\n-KITTY_WINDOW_ID\nSSH_AUTH_SOCK=/tmp/ssh.sock\n", str);
+}
+
+test "getEnvValue extracts set value or returns EnvVarNotFound for unset" {
+    const payload = "DISPLAY=:1\n-KITTY_WINDOW_ID\nSSH_AUTH_SOCK=/tmp/ssh.sock\n";
+
+    try std.testing.expectEqualStrings(":1", try getEnvValue("DISPLAY", payload));
+    try std.testing.expectEqualStrings("/tmp/ssh.sock", try getEnvValue("SSH_AUTH_SOCK", payload));
+    try std.testing.expectError(error.EnvVarNotFound, getEnvValue("KITTY_WINDOW_ID", payload));
+    try std.testing.expectError(error.EnvVarNotFound, getEnvValue("NONEXISTENT", payload));
 }


### PR DESCRIPTION
When a client assumes the leader for a zmx session it sets the tracked environment variables for the session which can the user can then print using `zmx print-env {sesh}`.

This can be used inside a shell precmd hook to automatically set the leader's env vars to the shell session: `eval "$(zmx print-env .)"`.

Link: https://github.com/neurosnap/zmx/issues/225
Link: https://github.com/neurosnap/zmx/issues/104