### PR TITLE
fix(docs): remove stale list --where references

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Commands:
   [p]rint <name> <text...>                 Inject text into session display
   [wr]ite <name> <file_path>               Write stdin to file_path through the session
   [d]etach                                 Detach all clients (ctrl+\\ for current client)
-  [l]ist|ls [--short|--where k=v]          List active sessions
+  [l]ist|ls [--short]                      List active sessions
   [g]et <name>                             Get session labels
   set <name> k=v ...                       Set session labels
   [un]set <name> key ...                   Remove session labels

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -164,7 +164,6 @@ const fish_completions =
     \\complete -c zmx -n "__fish_seen_subcommand_from r run" -s d -d 'Detach from the calling terminal; use `wait` to track its status'
     \\complete -c zmx -n "__fish_seen_subcommand_from r run" -l fish -d 'Required when the session runs fish shell'
     \\complete -c zmx -n "__fish_seen_subcommand_from l list" -l short -d 'Short output'
-    \\complete -c zmx -n "__fish_seen_subcommand_from l list" -l where -d 'Filter by label (key=value)' -r
     \\complete -c zmx -n "__fish_seen_subcommand_from k kill" -l force -d 'Force kill'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l vt -d 'History format for escape sequences'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l html -d 'History format for escape sequences'

--- a/src/main.zig
+++ b/src/main.zig
@@ -427,7 +427,7 @@ fn help(io: std.Io) !void {
         \\  [p]rint <name> <text...>                 Inject text into session display
         \\  [wr]ite <name> <file_path>               Write stdin to file_path through the session
         \\  [d]etach                                 Detach all clients (ctrl+\\ for current client)
-        \\  [l]ist|ls [--short|--where k=v]          List active sessions
+        \\  [l]ist|ls [--short]                      List active sessions
         \\  [g]et <name>                             Get session labels
         \\  set <name> k=v ...                     Set session labels (k= to remove)
         \\  [cl]ear <name>                           Clear all session labels


### PR DESCRIPTION
## Summary

- remove the unsupported `--where` option from the README command synopsis
- remove it from the built-in CLI help
- remove the stale Fish completion

## Context

Follow-up to https://github.com/neurosnap/zmx/issues/217: `--where` was removed from the final implementation in favor of composing `zmx list` with Unix tools, but it remained advertised in documentation and completion output.

This PR only synchronizes the advertised interface; it does not change runtime behavior.

## Validation

- `git diff --check`
- confirmed no `--where` references remain in the repository
- Zig/build tests not run locally because Zig is unavailable and the Docker daemon is not running