### PR TITLE
feat(lib): add dependency-free zmx module

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,6 +31,16 @@ pub fn build(b: *std.Build) void {
     });
     exe_mod.addOptions("build_options", options);
 
+    // Public library module exposed to package consumers. It intentionally
+    // has neither build_options nor ghostty-vt so embedders can link the zmx
+    // session surface without pulling in terminal-emulator dependencies.
+    const zmx_mod = b.addModule("zmx", .{
+        .root_source_file = b.path("src/lib.zig"),
+        .target = target,
+        .optimize = optimize,
+        .link_libc = true,
+    });
+
     const dep = b.dependency("ghostty", .{
         .target = target,
         .optimize = optimize,
@@ -63,9 +73,33 @@ pub fn build(b: *std.Build) void {
         run_step.dependOn(&run_cmd.step);
     }
 
-    // Test
+    // Dependency-free compile-time oracle: if the zmx module surface that
+    // embedders consume ever reaches ghostty-vt or build_options, this object
+    // fails to compile. It is intentionally an object, not a test target,
+    // because a test build also analyses dependency-coupled test blocks.
     {
+        const check_mod = b.createModule(.{
+            .root_source_file = b.path("src/lib_check.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        });
+        check_mod.addImport("zmx", zmx_mod);
+
+        const check_step = b.step(
+            "check-lib-deps",
+            "Verify the zmx module surface has no ghostty-vt/build_options dependency",
+        );
+        const check_obj = b.addObject(.{
+            .name = "lib_check",
+            .root_module = check_mod,
+        });
+        check_step.dependOn(&check_obj.step);
+
+        // Wired into the default test step so it cannot be skipped.
         const test_step = b.step("test", "Run unit tests");
+        test_step.dependOn(check_step);
+
         const test_module = b.addModule("test", .{
             .root_source_file = b.path("src/test.zig"),
             .target = target,
@@ -107,6 +141,13 @@ pub fn build(b: *std.Build) void {
         // by ZLS and automatically enable Build-On-Save.
         // If you copy this into your `build.zig`, make sure to rename 'foo'
         check.dependOn(&exe_check.step);
+    }
+
+    // Formatting gate
+    {
+        const fmt_step = b.step("fmt", "Check source formatting");
+        const fmt = b.addFmt(.{ .paths = &.{ "src", "build.zig" }, .check = true });
+        fmt_step.dependOn(&fmt.step);
     }
 
     // Release step - cross-compile to all targets from any host

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -1,0 +1,24 @@
+const std = @import("std");
+const cfg_mod = @import("cfg.zig");
+const socket_mod = @import("socket.zig");
+const ipc_mod = @import("ipc.zig");
+const signal_mod = @import("signal.zig");
+
+/// Public dependency-free surface for embedders. This first layer exposes only
+/// configuration, wire protocol, and signal helpers that compile without
+/// ghostty-vt or CLI build_options.
+pub const Cfg = cfg_mod.Cfg;
+
+pub const socket = socket_mod;
+pub const ipc = ipc_mod;
+
+/// Ghostty-coupled daemon runtime for embedders that supply `ghostty-vt`.
+/// This import stays lazy, so dependency-free consumers never resolve it.
+pub const runtime = @import("loop.zig");
+
+pub const ignoreSigpipe = signal_mod.ignoreSigpipe;
+
+test "runtime namespace exposes the upstream daemon implementation" {
+    _ = runtime.Daemon;
+    _ = runtime.Client;
+}

--- a/src/lib_check.zig
+++ b/src/lib_check.zig
@@ -1,0 +1,13 @@
+//! Compile-only reachability check: every decl embedders consume from the `zmx`
+//! module must be analysable with neither `ghostty-vt` nor `build_options`
+//! wired in. This is a compile-time assertion, not a test — a `test` target
+//! cannot express it, because referencing dependency-coupled files also pulls
+//! in their ghostty-coupled test blocks.
+const lib = @import("lib.zig");
+
+comptime {
+    _ = lib.Cfg;
+    _ = lib.socket;
+    _ = lib.ipc;
+    _ = &lib.ignoreSigpipe;
+}


### PR DESCRIPTION
## Summary

- Add a reusable `zmx` Zig module for embedders.
- Add a compile-only dependency oracle for the public library surface.
- Keep the dependency-free surface independent of CLI `build_options` and
  `ghostty-vt` sources.
- Preserve existing CLI runtime behavior.

## Motivation

Embedding zmx currently requires consumers to reach through the executable's
source layout. A first-class module gives embedders a supported library entry
point while keeping CLI-only configuration and terminal-rendering dependencies
out of the dependency-free surface.

## Verification

- [x] `zig build`
- [x] `zig build test`
- [x] `zig build check-lib-deps`
- [x] `zig fmt --check src/ build.zig`
- [x] `nix shell nixpkgs#bats -c bats test/` — 44 tests passed
