### PR TITLE
docs: add rootshell to community tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,3 +612,4 @@ abduco provides session management (i.e. it allows programs to be run independen
 - [zsm](https://github.com/mdsakalu/zmx-session-manager) -- TUI session manager for zmx. List, preview, filter, and kill sessions from an interactive terminal UI.
 - [zmosh](https://github.com/mmonad/zmosh) -- A fork of zmx that adds encrypted UDP auto-reconnect for remote sessions (like mosh).
 - [zmx-picker](https://github.com/EarthmanMuons/zmx-picker) -- fzf-based session picker and project launcher. Jump to a running zmx session or start one inside any of your git/jj repos.
+- [rootshell](https://github.com/kitknox/rootshell) -- Metal-accelerated terminal for iPhone, iPad, Vision Pro, and Mac. Lists active zmx sessions with live previews and can auto-attach on connect.


### PR DESCRIPTION
rootshell is a free, Metal-accelerated terminal emulator for iPhone, iPad, Vision Pro, and Mac that treats zmx as a first-class multiplexer: it lists active zmx sessions with per-multiplexer detail and a live terminal preview, and it can automatically attach to or create a zmx session on connect — the same way it handles tmux and herdr.

Source: https://github.com/kitknox/rootshell

Happy to adjust wording or placement.