### PR TITLE
feat(history): capture the active screen with bounded scrollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ Commands:
   [h]elp                                   Show this help
 ```
 
+### screen and scrollback capture
+
+`zmx history --screen <name>` prints only the active screen, and
+`zmx history --scrollback N <name>` adds up to `N` rows of scrollback above it.
+Both work with `--vt` and `--html`. The daemon selects the rows before
+formatting them, so a tool that polls a session's current state no longer
+receives and discards the whole history. Alternate screens have no scrollback,
+so they always return just the screen. Sessions whose daemon predates this
+feature keep serving plain `history`; the scoped flags report that the daemon
+is too old.
+
 ## nested sessions
 
 Nested sessions are not supported. Inside a session `ZMX_SESSION` is set, and `attach` reads it: instead of creating another client it switches the calling terminal to the session you named.

--- a/src/completions.zig
+++ b/src/completions.zig
@@ -40,9 +40,13 @@ const bash_completions =
     \\  fi
     \\
     \\  case "$prev" in
-    \\    attach|run|send|print|write|kill|history|get|set|clear|print-env|wait|tail)
+    \\    attach|run|send|print|write|kill|get|set|clear|print-env|wait|tail)
     \\      local sessions=$(zmx list --short 2>/dev/null | tr '\n' ' ')
     \\      COMPREPLY=($(compgen -W "$sessions" -- "$cur"))
+    \\      ;;
+    \\    history)
+    \\      local sessions=$(zmx list --short 2>/dev/null | tr '\n' ' ')
+    \\      COMPREPLY=($(compgen -W "--screen --scrollback --vt --html $sessions" -- "$cur"))
     \\      ;;
     \\    completions)
     \\      COMPREPLY=($(compgen -W "bash zsh fish nu" -- "$cur"))
@@ -97,8 +101,12 @@ const zsh_completions =
     \\      ;;
     \\    args)
     \\      case $words[2] in
-    \\        attach|a|kill|k|run|r|send|s|print|p|write|wr|history|get|g|set|clear|print-env|hi|wait|w|tail|t)
+    \\        attach|a|kill|k|run|r|send|s|print|p|write|wr|get|g|set|clear|print-env|wait|w|tail|t)
     \\          _zmx_sessions
+    \\          ;;
+    \\        history|hi)
+    \\          _zmx_sessions
+    \\          _values 'options' '--screen' '--scrollback' '--vt' '--html'
     \\          ;;
     \\        completions|c)
     \\          _values 'shell' 'bash' 'zsh' 'fish' 'nu'
@@ -169,6 +177,8 @@ const fish_completions =
     \\complete -c zmx -n "__fish_seen_subcommand_from k kill" -l force -d 'Force kill'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l vt -d 'History format for escape sequences'
     \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l html -d 'History format for escape sequences'
+    \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l screen -d 'Output only the active screen'
+    \\complete -c zmx -n "__fish_seen_subcommand_from hi history" -l scrollback -d 'Rows of scrollback to add above the screen' -r
     \\complete -c zmx -n "__fish_seen_subcommand_from print-env" -s s -l shell -d 'Output POSIX export/unset commands for eval'
 ;
 
@@ -216,7 +226,7 @@ const nu_completions =
     \\
     \\export extern "zmx detach" []
     \\export extern "zmx list" [--short]
-    \\export extern "zmx history" [name: string@"nu-complete zmx sessions", --vt, --html]
+    \\export extern "zmx history" [name: string@"nu-complete zmx sessions", --vt, --html, --screen, --scrollback: int]
     \\export extern "zmx wait" [...sessions: string@"nu-complete zmx sessions"]
     \\export extern "zmx tail" [...sessions: string@"nu-complete zmx sessions"]
     \\export extern "zmx version" []

--- a/src/ipc.zig
+++ b/src/ipc.zig
@@ -26,6 +26,9 @@ pub const Tag = enum(u8) {
     EnvGet = 19,
     EnvSet = 20,
     EnvData = 21,
+    /// Scoped history: the active screen plus a bounded number of
+    /// preceding scrollback rows. Request payload is `Capture`.
+    Capture = 22,
     // Non-exhaustive: this enum comes off the wire via bytesToValue and
     // @enumFromInt, so out-of-range values are representable
     // rather than UB. Switches must handle `_` (unknown tag).
@@ -52,6 +55,14 @@ pub const Resize = packed struct {
     pub fn winsize(self: Resize) cross.c.struct_winsize {
         return .{ .ws_row = self.rows, .ws_col = self.cols, .ws_xpixel = self.xpixel, .ws_ypixel = self.ypixel };
     }
+};
+
+/// Request payload for `Tag.Capture`. `format` is a `util.HistoryFormat`
+/// and `rows` is how many scrollback rows to include above the active
+/// screen; zero returns only the screen.
+pub const Capture = packed struct {
+    format: u8,
+    rows: u32,
 };
 
 pub fn getTerminalSize(fd: i32) Resize {
@@ -344,7 +355,8 @@ test "Tag wire values are frozen" {
         .{ Tag.Run, 9 },       .{ Tag.Ack, 10 },          .{ Tag.Switch, 11 },
         .{ Tag.Write, 12 },    .{ Tag.TaskComplete, 13 }, .{ Tag.LabelGet, 14 },
         .{ Tag.LabelSet, 15 }, .{ Tag.LabelClear, 16 },   .{ Tag.LabelData, 17 },
-        .{ Tag.Send, 18 },
+        .{ Tag.Send, 18 },     .{ Tag.EnvGet, 19 },       .{ Tag.EnvSet, 20 },
+        .{ Tag.EnvData, 21 },  .{ Tag.Capture, 22 },
     }) |p| try std.testing.expectEqual(@as(u8, p[1]), @intFromEnum(p[0]));
 }
 

--- a/src/loop.zig
+++ b/src/loop.zig
@@ -490,6 +490,7 @@ fn daemonLoop(daemon: *Daemon, gpa: std.mem.Allocator, io: std.Io, server_sock_f
                         .EnvGet => try daemon.handleEnvGet(gpa, client),
                         .EnvSet => try daemon.handleEnvSet(gpa, client, msg.payload),
                         .History => try daemon.handleHistory(gpa, client, &term, msg.payload),
+                        .Capture => try daemon.handleCapture(gpa, client, &term, msg.payload),
                         .Run => try daemon.handleRun(gpa, io, client, msg.payload),
                         .Ack, .TaskComplete, .LabelData, .EnvData => {},
                         .Write => try daemon.handleWrite(gpa, client, msg.payload),
@@ -1146,6 +1147,23 @@ pub const Daemon = struct {
             try ipc.appendMessage(gpa, &client.write_buf, .History, "");
             client.has_pending_output = true;
         }
+    }
+
+    pub fn handleCapture(
+        self: *Daemon,
+        gpa: std.mem.Allocator,
+        client: *Client,
+        term: *ghostty_vt.Terminal,
+        payload: []const u8,
+    ) !void {
+        if (payload.len != @sizeOf(ipc.Capture)) return;
+        const request = std.mem.bytesToValue(ipc.Capture, payload);
+        const format = std.enums.fromInt(util.HistoryFormat, request.format) orelse return;
+        self.setPwd(term);
+        const output = util.serializeTerminalRange(gpa, term, format, request.rows);
+        defer if (output) |text| gpa.free(text);
+        try ipc.appendMessage(gpa, &client.write_buf, .Capture, output orelse "");
+        client.has_pending_output = true;
     }
 
     pub fn handleRun(self: *Daemon, gpa: std.mem.Allocator, io: std.Io, client: *Client, payload: []const u8) !void {

--- a/src/main.zig
+++ b/src/main.zig
@@ -128,6 +128,7 @@ pub fn main(init: std.process.Init) !void {
     } else if (std.mem.eql(u8, cmd, "history") or std.mem.eql(u8, cmd, "hi")) {
         var session_name: ?[]const u8 = null;
         var format: util.HistoryFormat = .plain;
+        var scrollback_rows: ?u32 = null;
         while (args.next()) |arg| {
             if (std.mem.eql(u8, arg, "--help") or std.mem.eql(u8, arg, "-h")) {
                 return help(io);
@@ -135,6 +136,13 @@ pub fn main(init: std.process.Init) !void {
                 format = .vt;
             } else if (std.mem.eql(u8, arg, "--html")) {
                 format = .html;
+            } else if (std.mem.eql(u8, arg, "--screen")) {
+                if (scrollback_rows != null) return printError(io, "--screen and --scrollback may only be specified once", .{});
+                scrollback_rows = 0;
+            } else if (std.mem.eql(u8, arg, "--scrollback")) {
+                if (scrollback_rows != null) return printError(io, "--screen and --scrollback may only be specified once", .{});
+                const count = args.next() orelse return printError(io, "--scrollback requires a row count", .{});
+                scrollback_rows = std.fmt.parseInt(u32, count, 10) catch return printError(io, "invalid scrollback row count: {s}", .{count});
             } else if (session_name == null) {
                 session_name = arg;
             }
@@ -145,7 +153,7 @@ pub fn main(init: std.process.Init) !void {
         });
         const sesh = try socket.getSeshName(gpa, raw_name);
         defer gpa.free(sesh);
-        return history(gpa, io, &cfg, sesh, format);
+        return history(gpa, io, &cfg, sesh, format, scrollback_rows);
     } else if (std.mem.eql(u8, cmd, "attach") or std.mem.eql(u8, cmd, "a")) {
         var attach_args: std.ArrayList([]const u8) = .empty;
         defer attach_args.deinit(gpa);
@@ -545,8 +553,14 @@ fn help(io: std.Io) !void {
         \\  This should generally be used with `tail` to print the last lines
         \\  of the session's scrollback history.
         \\
+        \\  --screen outputs only the active screen, and --scrollback N adds up
+        \\  to N rows of scrollback above it, so pollers can skip formatting
+        \\  history they would discard. Both work with --vt and --html.
+        \\
         \\  Examples:
         \\    zmx history <session> | tail -100
+        \\    zmx history --screen <session>
+        \\    zmx history --scrollback 512 <session>
         \\
         \\Run:
         \\  Commands run inside a PTY using bash
@@ -1437,7 +1451,7 @@ fn fetchHistory(
     return error.NoHistoryResponse;
 }
 
-fn history(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat) !void {
+fn history(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []const u8, format: util.HistoryFormat, scrollback_rows: ?u32) !void {
     std.log.info("history session={s}", .{session_name});
 
     const socket_path = socket.getSocketPath(alloc, cfg.socket_dir, session_name) catch |err| switch (err) {
@@ -1460,11 +1474,29 @@ fn history(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []cons
     };
     defer lib_posix.close(fd);
 
-    const format_byte = [_]u8{@intFromEnum(format)};
-    ipc.send(fd, .History, &format_byte) catch |err| switch (err) {
-        error.BrokenPipe, error.ConnectionResetByPeer => return,
-        else => return err,
-    };
+    const reply_tag: ipc.Tag = if (scrollback_rows != null) .Capture else .History;
+    if (scrollback_rows) |rows| {
+        // zeroes() so asBytes() doesn't ship packed struct padding.
+        var request = std.mem.zeroes(ipc.Capture);
+        request.format = @intFromEnum(format);
+        request.rows = rows;
+        ipc.send(fd, .Capture, std.mem.asBytes(&request)) catch |err| switch (err) {
+            error.BrokenPipe, error.ConnectionResetByPeer => return,
+            else => return err,
+        };
+        // Requests are handled in connection order. Info is a compatibility
+        // barrier: old daemons ignore Capture but still answer Info.
+        ipc.send(fd, .Info, "") catch |err| switch (err) {
+            error.BrokenPipe, error.ConnectionResetByPeer => return,
+            else => return err,
+        };
+    } else {
+        const format_byte = [_]u8{@intFromEnum(format)};
+        ipc.send(fd, .History, &format_byte) catch |err| switch (err) {
+            error.BrokenPipe, error.ConnectionResetByPeer => return,
+            else => return err,
+        };
+    }
 
     var sb = try ipc.SocketBuffer.init(alloc);
     defer sb.deinit();
@@ -1481,9 +1513,12 @@ fn history(alloc: std.mem.Allocator, io: std.Io, cfg: *Cfg, session_name: []cons
         if (n == 0) return;
 
         while (sb.next()) |msg| {
-            if (msg.header.tag == .History) {
+            if (msg.header.tag == reply_tag) {
                 _ = lib_posix.write(lib_posix.STDOUT_FILENO, msg.payload) catch return;
                 return;
+            }
+            if (scrollback_rows != null and msg.header.tag == .Info) {
+                return printError(io, "session \"{s}\" does not support --screen/--scrollback (daemon too old?)", .{session_name});
             }
         }
     }

--- a/src/util.zig
+++ b/src/util.zig
@@ -901,6 +901,18 @@ pub fn serializeTerminal(
     term: *ghostty_vt.Terminal,
     format: HistoryFormat,
 ) ?[]const u8 {
+    return serializeTerminalRange(alloc, term, format, null);
+}
+
+/// Formats the active screen and at most `scrollback_rows` preceding physical
+/// rows. Null preserves whole-history formatting. Alternate screens have no
+/// scrollback, so their selection always stays inside the current grid.
+pub fn serializeTerminalRange(
+    alloc: std.mem.Allocator,
+    term: *ghostty_vt.Terminal,
+    format: HistoryFormat,
+    scrollback_rows: ?u32,
+) ?[]const u8 {
     var builder: std.Io.Writer.Allocating = .init(alloc);
     defer builder.deinit();
 
@@ -911,6 +923,18 @@ pub fn serializeTerminal(
     };
     var term_formatter = ghostty_vt.formatter.TerminalFormatter.init(term, opts);
     term_formatter.content = .{ .selection = null };
+    if (scrollback_rows) |rows| {
+        const pages = &term.screens.active.pages;
+        const active_top = pages.getTopLeft(.active);
+        const top = active_top.up(rows) orelse pages.getTopLeft(.screen);
+        const bottom = pages.pin(.{ .active = .{
+            .x = @intCast(pages.cols - 1),
+            .y = @intCast(pages.rows - 1),
+        } }) orelse return null;
+        term_formatter.content = .{
+            .selection = ghostty_vt.Selection.init(top, bottom, false),
+        };
+    }
     term_formatter.extra = switch (format) {
         .plain => .none,
         .vt => .{
@@ -1686,6 +1710,42 @@ test "serializeTerminal vt replays the pwd without a NUL sentinel" {
 
     try testing.expect(std.mem.indexOf(u8, output, "\x1b]7;file://myhost/private/tmp\x1b\\") != null);
     try testing.expectEqual(@as(?usize, null), std.mem.indexOfScalar(u8, output, 0));
+}
+
+test "serializeTerminalRange screen only returns the active screen" {
+    const alloc = testing.allocator;
+    var term = try testCreateTerminal(alloc, testing.io, 80, 3, "1\r\n2\r\n3\r\n4\r\n5");
+    defer term.deinit(alloc);
+
+    const output = serializeTerminalRange(alloc, &term, .plain, 0) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+    try testing.expectEqualStrings("3\n4\n5", output);
+}
+
+test "serializeTerminalRange adds the requested scrollback rows" {
+    const alloc = testing.allocator;
+    var term = try testCreateTerminal(alloc, testing.io, 80, 3, "1\r\n2\r\n3\r\n4\r\n5");
+    defer term.deinit(alloc);
+
+    const output = serializeTerminalRange(alloc, &term, .plain, 1) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+    try testing.expectEqualStrings("2\n3\n4\n5", output);
+
+    const all = serializeTerminalRange(alloc, &term, .plain, 100) orelse return error.TestUnexpectedNull;
+    defer alloc.free(all);
+    const full = serializeTerminal(alloc, &term, .plain) orelse return error.TestUnexpectedNull;
+    defer alloc.free(full);
+    try testing.expectEqualStrings(full, all);
+}
+
+test "serializeTerminalRange alternate screen returns only its grid" {
+    const alloc = testing.allocator;
+    var term = try testCreateTerminal(alloc, testing.io, 80, 3, "1\r\n2\r\n3\r\n4\r\n5\x1b[?1049h\x1b[Halt");
+    defer term.deinit(alloc);
+
+    const output = serializeTerminalRange(alloc, &term, .plain, 100) orelse return error.TestUnexpectedNull;
+    defer alloc.free(output);
+    try testing.expectEqualStrings("alt", output);
 }
 
 fn testCreateTerminal(alloc: std.mem.Allocator, io: std.Io, cols: u16, rows: u16, vt_data: []const u8) !ghostty_vt.Terminal {


### PR DESCRIPTION
Hey Neurosnap!
Hope you're doing great man!

I'm the greatest fan of zmx, it's honestly such an amazing utility.

My whole ADE is based on it basically and it solved so many issues for me (Client <> Host architecture. Web. Mobile. Converting agent CLIs to a chat GUI view. Way more.)

Now I was looking into the polling being done by the Chat View with Astra and it says that it can be optimized in zmx so that the history command doesn't send rows that aren't required (like when using the tail argument)

The idea of this PR is to only get the needed rows from zmx to lower the cpu/memory required for reading from zmx (I need to poll the terminal a lot while the agent is working)

---

Summary by Astra high:

Consumers that poll a terminal's current state currently have to request all history and discard most of it. This adds daemon-side selection so the formatter and socket only handle the requested rows.

- `zmx history --screen SESSION` captures the current grid of the active screen.
- `zmx history --scrollback N SESSION` includes that grid plus up to N preceding physical rows.
- Both support plain text, `--vt`, and `--html`, with help, README documentation, and shell completions.

The existing history command and History IPC payload remain unchanged. A new optional Capture tag carries the format and scrollback count as a packed struct. An Info request follows it as an ordering barrier: an older daemon answers Info without Capture, and the CLI reports that the daemon is too old (same shape as the labels error) instead of silently returning an unbounded result or waiting for a capability timeout. Existing sessions do not need to restart to continue using ordinary history.

Open question: would you prefer extending the History payload from 1 to 5 bytes instead? Old daemons already read only the first byte and would return full history, which drops the new tag and the barrier at the cost of a silent fallback.

Selection reads Ghostty's already-updated active buffer, so cursor movement and in-place redraws are preserved. Alternate screens return only their grid. The row count refers to physical rows, including wrapping and blank rows, rather than a client's scrolled-back viewport.

Validation on macOS arm64 with Zig 0.16.0 (using a local SDK header overlay for the installed SDK):

- `zig build -Doptimize=ReleaseSafe` passed.
- `zig build test -Doptimize=ReleaseSafe` passed, 98/98 tests (three new `serializeTerminalRange` tests: screen only, requested rows with clamping, alternate screen).
- `zig fmt --check` and `git diff --check` passed.
- Disposable-session checks verified exact recent-history suffixes, the requested extra row count, alternate-screen isolation, and in-place redraws. One 1,207-line capture shrank from 11,200 bytes to 4,817 bytes with `--scrollback 512`.

Draft for review of the CLI and additive protocol shape.

